### PR TITLE
Fix docker-compose for Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed issue where local docker-compose would not work due to missing connection string - [#234](https://github.com/DigitalExcellence/dex-backend/issues/234)
+
 ### Security
 
 

--- a/IdentityServer/Dockerfile.dev
+++ b/IdentityServer/Dockerfile.dev
@@ -4,6 +4,8 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
 
 ENV App__Self__IssuerUri = ''
 
+ENV ConnectionStrings__DefaultConnection = ''
+
 ARG BuildConfiguration=Debug
 
 WORKDIR /app

--- a/IdentityServer/Dockerfile.dev
+++ b/IdentityServer/Dockerfile.dev
@@ -21,6 +21,7 @@ FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 WORKDIR /app
 
 COPY --from=build-env /app/IdentityServer/bin/Debug/netcoreapp3.1 .
+COPY --from=build-env /app/IdentityServer/wwwroot ./wwwroot
 COPY --from=build-env /app/dex-identity.pfx . 
 
 ENTRYPOINT ["dotnet", "6_IdentityServer.dll", "--environment=Development"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     depends_on:
       - db
     environment: 
-      - ConnectionStrings__DefaultConnection=Server=172.16.238.2;Database=identity;User=sa;Password=Dexcelence!1;
+      - ConnectionStrings__DefaultConnection=Server=db;Database=identity;User=sa;Password=Dexcelence!1;
       - App__Self__IssuerUri=https://172.16.238.3:5004
       - App__Api__DeXApiUrl=https://172.16.238.4
       - ASPNETCORE_URLS=https://+;
@@ -39,7 +39,7 @@ services:
     depends_on:
       - db
     environment: 
-      - ConnectionStrings__DefaultConnection=Server=172.16.238.2;Database=master;User=sa;Password=Dexcelence!1;
+      - ConnectionStrings__DefaultConnection=Server=db;Database=master;User=sa;Password=Dexcelence!1;
       - App__IdentityServer__IdentityUrl=https://172.16.238.3
       - ASPNETCORE_URLS=https://+;
       - ASPNETCORE_HTTPS_PORT=5001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,10 @@ services:
     build:
       context: .
       dockerfile: IdentityServer/Dockerfile.dev
+    depends_on:
+      - db
     environment: 
+      - ConnectionStrings__DefaultConnection=Server=172.16.238.2;Database=master;User=sa;Password=Dexcelence!1;
       - App__Self__IssuerUri=https://172.16.238.3:5004
       - App__Api__DeXApiUrl=https://172.16.238.4
       - ASPNETCORE_URLS=https://+;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     depends_on:
       - db
     environment: 
-      - ConnectionStrings__DefaultConnection=Server=172.16.238.2;Database=master;User=sa;Password=Dexcelence!1;
+      - ConnectionStrings__DefaultConnection=Server=172.16.238.2;Database=identity;User=sa;Password=Dexcelence!1;
       - App__Self__IssuerUri=https://172.16.238.3:5004
       - App__Api__DeXApiUrl=https://172.16.238.4
       - ASPNETCORE_URLS=https://+;


### PR DESCRIPTION
## Description

Docker-compose was broken due to the addition of persistence storage #159 in the Identity Server. I fixed it by adding a connection string to the IDS.
Tested this with @juliaslaats and @liekevdvoort and it now works for them.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I did not update API Controllers, if I did, I added/changed Postman tests
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.
These steps will be used during release testing.

1. Follow getting-started docker guide

## Link to issue

Closes: #234
