### PR TITLE
Feature/225 swagger documentation

### DIFF
--- a/API/Controllers/EmbedController.cs
+++ b/API/Controllers/EmbedController.cs
@@ -39,7 +39,6 @@ namespace API.Controllers
     /// <seealso cref="Microsoft.AspNetCore.Mvc.ControllerBase" />
     [Route("api/[controller]")]
     [ApiController]
-    [Produces("application/json")]
     public class EmbedController : ControllerBase
     {
         private readonly IEmbedService embedService;

--- a/API/Controllers/EmbedController.cs
+++ b/API/Controllers/EmbedController.cs
@@ -155,7 +155,7 @@ namespace API.Controllers
         /// <response code="401">If the user is not allowed to create an embed project.</response>
         [HttpPost]
         [Authorize]
-        [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.Created)]
+        [ProducesResponseType(typeof(EmbeddedProjectResourceResult), (int) HttpStatusCode.Created)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.Unauthorized)]
         public async Task<IActionResult> CreateEmbeddedProject(EmbeddedProjectResource embedResource)
@@ -239,7 +239,7 @@ namespace API.Controllers
         /// <response code="404">If the embedded project could not be found with the specified guid</response>
         [HttpDelete("{guid}")]
         [Authorize]
-        [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.OK)]
+        [ProducesResponseType((int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.NotFound)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.Unauthorized)]
         public async Task<IActionResult> DeleteEmbeddedProject(string guid)

--- a/API/Controllers/HighlightController.cs
+++ b/API/Controllers/HighlightController.cs
@@ -164,7 +164,7 @@ namespace API.Controllers
         /// </summary>
         /// <param name="highlightResource">The highlight resource.</param>
         /// <returns>The created highlight resource result.</returns>
-        /// <response code="200">Returns the created highlight resource result</response>
+        /// <response code="201">Returns the created highlight resource result</response>
         /// <response code="400">If highlight resource is not specified or failed saving highlight to database</response>
         [HttpPost]
         [Authorize(Policy = nameof(Defaults.Scopes.HighlightWrite))]
@@ -187,7 +187,6 @@ namespace API.Controllers
 
             try
             {
-
                 highlightService.Add(highlight);
                 highlightService.Save();
                 return Created(nameof(CreateHighlight), mapper.Map<Highlight, HighlightResourceResult>(highlight));

--- a/API/Controllers/HighlightController.cs
+++ b/API/Controllers/HighlightController.cs
@@ -37,7 +37,6 @@ namespace API.Controllers
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
-    [Produces("application/json")]
     public class HighlightController : ControllerBase
     {
         private readonly IHighlightService highlightService;

--- a/API/Controllers/HighlightController.cs
+++ b/API/Controllers/HighlightController.cs
@@ -248,7 +248,7 @@ namespace API.Controllers
         /// <response code="404">If no highlight is found with the specified id</response>
         [HttpDelete("{highlightId}")]
         [Authorize(Policy = nameof(Defaults.Scopes.HighlightWrite))]
-        [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.OK)]
+        [ProducesResponseType((int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.NotFound)]
         public async Task<IActionResult> DeleteHighlight(int highlightId)
         {

--- a/API/Controllers/ProjectController.cs
+++ b/API/Controllers/ProjectController.cs
@@ -37,7 +37,6 @@ namespace API.Controllers
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
-    [Produces("application/json")]
     public class ProjectController : ControllerBase
     {
         private readonly IMapper mapper;

--- a/API/Controllers/RoleController.cs
+++ b/API/Controllers/RoleController.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using API.Resources;
 using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
@@ -10,7 +7,9 @@ using Models;
 using Models.Defaults;
 using Serilog;
 using Services.Services;
+using System.Collections.Generic;
 using System.Net;
+using System.Threading.Tasks;
 using static Models.Defaults.Defaults;
 
 namespace API.Controllers
@@ -20,7 +19,6 @@ namespace API.Controllers
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
-    [Produces("application/json")]
     public class RoleController : ControllerBase
     {
         private readonly IMapper mapper;

--- a/API/Controllers/RoleController.cs
+++ b/API/Controllers/RoleController.cs
@@ -251,7 +251,7 @@ namespace API.Controllers
         [HttpDelete("{roleId}")]
         [Authorize(Policy = nameof(Scopes.RoleWrite))]
         [ProducesResponseType((int) HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.OK)]
+        [ProducesResponseType((int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.NotFound)]

--- a/API/Controllers/SearchController.cs
+++ b/API/Controllers/SearchController.cs
@@ -22,19 +22,19 @@ using Models;
 using Services.Services;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace API.Controllers
 {
-
     /// <summary>
-    ///     The controller that handles search requests
+    /// The controller that handles search requests
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
+    [Produces("application/json")]
     public class SearchController : ControllerBase
     {
-
         private readonly IMapper mapper;
 
         private readonly ISearchService searchService;
@@ -51,12 +51,16 @@ namespace API.Controllers
         }
 
         /// <summary>
-        ///     Search for projects
+        /// Search for projects
         /// </summary>
         /// <param name="query">The search query</param>
         /// <param name="projectFilterParamsResource">The parameters to filter, sort and paginate the projects</param>
         /// <returns>Search results</returns>
+        /// <response code="200">Returns search results</response>
+        /// <response code="400">If search request is invalid</response>
         [HttpGet("internal/{query}")]
+        [ProducesResponseType(typeof(ProjectResultsResource), (int) HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         public async Task<IActionResult> SearchInternalProjects(string query,
                                                                 [FromQuery] ProjectFilterParamsResource projectFilterParamsResource)
         {

--- a/API/Controllers/SearchController.cs
+++ b/API/Controllers/SearchController.cs
@@ -32,7 +32,6 @@ namespace API.Controllers
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
-    [Produces("application/json")]
     public class SearchController : ControllerBase
     {
         private readonly IMapper mapper;

--- a/API/Controllers/UserController.cs
+++ b/API/Controllers/UserController.cs
@@ -23,7 +23,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Models;
 using Models.Defaults;
-using RestSharp;
 using Serilog;
 using Services.Services;
 using System.Linq;
@@ -37,7 +36,6 @@ namespace API.Controllers
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
-    [Produces("application/json")]
     public class UserController : ControllerBase
     {
         private readonly IMapper mapper;

--- a/API/Controllers/WizardController.cs
+++ b/API/Controllers/WizardController.cs
@@ -15,26 +15,20 @@
 * If not, see https://www.gnu.org/licenses/lgpl-3.0.txt
 */
 
-using API.Resources;
-using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Models;
 using Services.Services;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Threading.Tasks;
 
 namespace API.Controllers
 {
     /// <summary>
-    ///     The controller that handles search requests
+    /// The controller that handles search requests
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
-    [Produces("application/json")]
     public class WizardController : ControllerBase
     {
         private readonly ISourceManagerService sourceManagerService;

--- a/API/Controllers/WizardController.cs
+++ b/API/Controllers/WizardController.cs
@@ -1,16 +1,16 @@
 /*
 * Digital Excellence Copyright (C) 2020 Brend Smits
-* 
-* This program is free software: you can redistribute it and/or modify 
-* it under the terms of the GNU Lesser General Public License as published 
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
 * by the Free Software Foundation version 3 of the License.
-* 
-* This program is distributed in the hope that it will be useful, 
-* but WITHOUT ANY WARRANTY; without even the implied warranty 
-* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty
+* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
-* 
-* You can find a copy of the GNU Lesser General Public License 
+*
+* You can find a copy of the GNU Lesser General Public License
 * along with this program, in the LICENSE.md file in the root project directory.
 * If not, see https://www.gnu.org/licenses/lgpl-3.0.txt
 */
@@ -24,6 +24,7 @@ using Services.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace API.Controllers
@@ -33,6 +34,7 @@ namespace API.Controllers
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
+    [Produces("application/json")]
     public class WizardController : ControllerBase
     {
         private readonly ISourceManagerService sourceManagerService;
@@ -51,8 +53,14 @@ namespace API.Controllers
         /// </summary>
         /// <param name="sourceURI">The source URI.</param>
         /// <returns>The filled in Project.</returns>
+        /// <response code="200">Returns the project with the specified source Uri</response>
+        /// <response code="400">If source Uri is not specified</response>
+        /// <response code="404">If the project could not be found with the specified source Uri</response>
         [HttpGet]
         [Authorize]
+        [ProducesResponseType(typeof(Project), (int) HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
+        [ProducesResponseType((int) HttpStatusCode.NotFound)]
         public IActionResult GetWizardInformation(Uri sourceURI)
         {
             if(sourceURI == null)

--- a/API/Filters/DefaultOperationFilter.cs
+++ b/API/Filters/DefaultOperationFilter.cs
@@ -19,6 +19,8 @@ namespace API.Filters
         /// <param name="context">Filter context</param>
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
+            // If there already is a consume attribute, this won't be overridden
+            // So only if nothing is configured, the default will be set to application/json
             bool hasConsumeAttribute = context.MethodInfo.GetCustomAttributes(true)
                                               .Union(context.MethodInfo.GetCustomAttributes(true))
                                               .OfType<ConsumesAttribute>()

--- a/API/Filters/DefaultOperationFilter.cs
+++ b/API/Filters/DefaultOperationFilter.cs
@@ -1,5 +1,7 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Linq;
 
 namespace API.Filters
 {
@@ -17,6 +19,17 @@ namespace API.Filters
         /// <param name="context">Filter context</param>
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
+            bool hasConsumeAttribute = context.MethodInfo.GetCustomAttributes(true)
+                                              .Union(context.MethodInfo.GetCustomAttributes(true))
+                                              .OfType<ConsumesAttribute>()
+                                              .Count() != 0;
+            if(operation.RequestBody != null && !hasConsumeAttribute)
+            {
+                var mediaType = operation.RequestBody.Content["application/json"];
+                operation.RequestBody.Content.Clear();
+                operation.RequestBody.Content.Add("application/json", mediaType);
+            }
+
             foreach(string code in operation.Responses.Keys)
             {
                 if(operation.Responses[code]

--- a/API/Filters/DefaultOperationFilter.cs
+++ b/API/Filters/DefaultOperationFilter.cs
@@ -1,0 +1,31 @@
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace API.Filters
+{
+    /// <summary>
+    /// Filter for all endpoints to make sure that the response
+    /// media type will be set to 'application/json'
+    /// </summary>
+    public class DefaultOperationFilter : IOperationFilter
+    {
+        /// <summary>
+        /// Foreach http status code keep the media type for application/json
+        /// and remove the other media types
+        /// </summary>
+        /// <param name="operation">API Operation</param>
+        /// <param name="context">Filter context</param>
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            foreach(string code in operation.Responses.Keys)
+            {
+                if(operation.Responses[code]
+                            .Content.TryGetValue("application/json", out OpenApiMediaType mediaType))
+                {
+                    operation.Responses[code].Content.Clear();
+                    operation.Responses[code].Content.Add("application/json", mediaType);
+                }
+            }
+        }
+    }
+}

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -1,16 +1,16 @@
 /*
 * Digital Excellence Copyright (C) 2020 Brend Smits
-* 
-* This program is free software: you can redistribute it and/or modify 
-* it under the terms of the GNU Lesser General Public License as published 
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
 * by the Free Software Foundation version 3 of the License.
-* 
-* This program is distributed in the hope that it will be useful, 
-* but WITHOUT ANY WARRANTY; without even the implied warranty 
-* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty
+* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
-* 
-* You can find a copy of the GNU Lesser General Public License 
+*
+* You can find a copy of the GNU Lesser General Public License
 * along with this program, in the LICENSE.md file in the root project directory.
 * If not, see https://www.gnu.org/licenses/lgpl-3.0.txt
 */
@@ -141,13 +141,14 @@ namespace API
                     {
                         Title = "Dex API",
                         Version = "v1",
+                        Description = "Dex API Swagger surface. ",
                         License = new OpenApiLicense
                         {
                             Name = "GNU Lesser General Public License v3.0",
                             Url = new Uri("https://www.gnu.org/licenses/lgpl-3.0.txt")
                         }
                     });
-                o.IncludeXmlComments($"{AppDomain.CurrentDomain.BaseDirectory}{typeof(Startup).Namespace}.xml");
+                o.IncludeXmlComments($"{AppDomain.CurrentDomain.BaseDirectory}{typeof(Startup).Namespace}.xml", true);
                 o.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
                 {
                     Type = SecuritySchemeType.OAuth2,

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -17,6 +17,7 @@
 
 using API.Configuration;
 using API.Extensions;
+using API.Filters;
 using Data;
 using Data.Helpers;
 using FluentValidation.AspNetCore;
@@ -136,6 +137,7 @@ namespace API
 
             services.AddSwaggerGen(o =>
             {
+                o.OperationFilter<DefaultOperationFilter>();
                 o.SwaggerDoc("v1",
                     new OpenApiInfo
                     {

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -141,7 +141,7 @@ namespace API
                     {
                         Title = "Dex API",
                         Version = "v1",
-                        Description = "Dex API Swagger surface. ",
+                        Description = "Dex API Swagger surface.  Dex is a platform for students to share and work on projects. Share, work on and create new projects on Dex",
                         License = new OpenApiLicense
                         {
                             Name = "GNU Lesser General Public License v3.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved swagger documentation - [#225](https://github.com/DigitalExcellence/dex-backend/issues/225)
 
 ### Deprecated
 


### PR DESCRIPTION
## Description

Improved swagger documentation by adding:

- Response codes for each endpoint
- Return model for each endpoint
- Description for each controller
- Description for the general swagger page

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I did not update API Controllers, if I did, I added/changed Postman tests
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.
These steps will be used during release testing.

1. When you navigate to the swagger page, you should see below Dex API (below '/swagger/v1/swagger.json') a general description for the swagger page for Dex
2. After each controller name, there should be a small description visible for each controller individually
3. In a response tab, you should be able to see under 'Reponses' all the difference response codes with a short description, example value, schema, and media type.
4. All response media types should be set to application/json
5. All request media types should be set to application/json as the default value
5. When placing `[Consumes("")]' attribute for an endpoint, this endpoint won't be set to json automatically because you set your own custom configuration for the endpoint

## Link to issue

Closes: #225 