### PR TITLE
Bugfix/202 search function is too extensive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Release v.0.7.0-beta - 09-10-2020
 
 ### Added
-
 - Added descriptions for Project Highlights - [#219](https://github.com/DigitalExcellence/dex-backend/issues/219)
 
 ### Changed
@@ -36,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed issue with search functionality being too extensive. Now matching whole strings only - [#202](https://github.com/DigitalExcellence/dex-backend/issues/202)
 - Fixed a bug where GetAllHighlights endpoint returned status code 404 when empty. - [#207](https://github.com/DigitalExcellence/dex-backend/issues/207)
 - Fixed issue where local docker-compose would not work due to missing connection string - [#234](https://github.com/DigitalExcellence/dex-backend/issues/234)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed issue where swagger authorization was not working when running in docker-compose - [#200](https://github.com/DigitalExcellence/dex-backend/issues/200)
+- Fixed issue with search functionality being too extensive. Now matching whole strings only - [#202](https://github.com/DigitalExcellence/dex-backend/issues/202)
 
 ### Security
 
@@ -37,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed issue with search functionality being too extensive. Now matching whole strings only - [#202](https://github.com/DigitalExcellence/dex-backend/issues/202)
 - Fixed a bug where GetAllHighlights endpoint returned status code 404 when empty. - [#207](https://github.com/DigitalExcellence/dex-backend/issues/207)
 - Fixed issue where local docker-compose would not work due to missing connection string - [#234](https://github.com/DigitalExcellence/dex-backend/issues/234)
 

--- a/Repositories.Tests/ProjectRepositoryTest.cs
+++ b/Repositories.Tests/ProjectRepositoryTest.cs
@@ -349,8 +349,12 @@ namespace Repositories.Tests
             await DbContext.SaveChangesAsync();
 
             // Tests
+            // Id search
+            List<Project> retrieved = (List<Project>) await Repository.SearchAsync("1", 0, 1);
+            Assert.AreEqual(1, retrieved.Count, "Id search failed");
+
             // Name search
-            List<Project> retrieved = (List<Project>)await Repository.SearchAsync("exName", 10, 10);
+            retrieved = (List<Project>)await Repository.SearchAsync("exName", 10, 10);
             Assert.AreEqual(10, retrieved.Count, "Name search failed");
 
             // Description search

--- a/Repositories.Tests/ProjectRepositoryTest.cs
+++ b/Repositories.Tests/ProjectRepositoryTest.cs
@@ -29,7 +29,8 @@ namespace Repositories.Tests
             {
                 projects[i].User = users[i];
             }
-            DbContext.AddRange(projects);
+
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Test
@@ -230,8 +231,15 @@ namespace Repositories.Tests
             await DbContext.SaveChangesAsync();
 
             // Tests
+            // Id search
+            List<Project> retrieved = (List<Project>) await Repository.SearchAsync("1");
+            foreach(Project project in retrieved)
+            {
+                Assert.True(project.Id.ToString().Contains("1"), "Id search failed");
+            }
+
             // Name search
-            List<Project> retrieved = (List<Project>)await Repository.SearchAsync("exName");
+            retrieved = (List<Project>)await Repository.SearchAsync("exName");
             Assert.AreEqual(50, retrieved.Count, "Name search failed");
 
             // Description search
@@ -312,8 +320,12 @@ namespace Repositories.Tests
             await DbContext.SaveChangesAsync();
 
             // Tests
+            // Id search
+            List<Project> retrieved = (List<Project>) await Repository.SearchAsync("-1");
+            Assert.AreEqual(0, retrieved.Count);
+
             // Name search
-            List<Project> retrieved = (List<Project>)await Repository.SearchAsync("test");
+            retrieved = (List<Project>)await Repository.SearchAsync("test");
             Assert.AreEqual(0, retrieved.Count);
         }
 

--- a/Repositories.Tests/ProjectRepositoryTest.cs
+++ b/Repositories.Tests/ProjectRepositoryTest.cs
@@ -49,7 +49,7 @@ namespace Repositories.Tests
         [Test]
         public async Task GetAllWithUsersAsyncTest_NoProjects([UserDataSource(100)]List<User> users)
         {
-            DbContext.AddRange(users);
+            await DbContext.AddRangeAsync(users);
             await DbContext.SaveChangesAsync();
 
             // Test
@@ -67,7 +67,7 @@ namespace Repositories.Tests
             [ProjectDataSource(100)]List<Project> projects)
         {
             // Seed database
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Test
@@ -91,13 +91,11 @@ namespace Repositories.Tests
             // And seed database
             projects = SetStaticTestData(projects, users);
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
-            List<Project> retrieved;
-
             // Tests
-            retrieved = await Repository.GetAllWithUsersAsync(0, 1);
+            List<Project> retrieved = await Repository.GetAllWithUsersAsync(0, 1);
             Assert.AreEqual(1, retrieved.Count, "Get all with skip take failed");
 
             retrieved = await Repository.GetAllWithUsersAsync(0, 10);
@@ -123,7 +121,7 @@ namespace Repositories.Tests
             // And seed database
             projects = SetStaticTestData(projects, users);
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Tests
@@ -147,7 +145,7 @@ namespace Repositories.Tests
             // And seed database
             projects = SetStaticTestData(projects, users);
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Tests
@@ -228,27 +226,20 @@ namespace Repositories.Tests
             // And seed database
             projects = SetStaticTestData(projects, users);
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Tests
-            // Id search
-            List<Project> retrieved = (List<Project>)await Repository.SearchAsync("1");
-            foreach (Project project in retrieved)
-            {
-                Assert.True(project.Id.ToString().Contains("1"), "Id search failed");
-            }
-
             // Name search
-            retrieved = (List<Project>)await Repository.SearchAsync("abc");
+            List<Project> retrieved = (List<Project>)await Repository.SearchAsync("exName");
             Assert.AreEqual(50, retrieved.Count, "Name search failed");
 
             // Description search
-            retrieved = (List<Project>)await Repository.SearchAsync("def");
+            retrieved = (List<Project>)await Repository.SearchAsync("defex");
             Assert.AreEqual(50, retrieved.Count, "Description search failed");
 
             // Short Description search
-            retrieved = (List<Project>)await Repository.SearchAsync("ghij");
+            retrieved = (List<Project>)await Repository.SearchAsync("ghijex");
             Assert.AreEqual(50, retrieved.Count, "ShortDescription search failed");
 
             // Uri search
@@ -256,12 +247,12 @@ namespace Repositories.Tests
             Assert.AreEqual(50, retrieved.Count, "Uri search failed");
 
             // User name search
-            retrieved = (List<Project>)await Repository.SearchAsync("xyz");
+            retrieved = (List<Project>)await Repository.SearchAsync("xyzex");
             Assert.AreEqual(50, retrieved.Count, "User name search failed");
 
             // Combined search
             retrieved = (List<Project>)await Repository.SearchAsync("ex");
-            Assert.AreEqual(100, retrieved.Count, "Combined search failed");
+            Assert.AreEqual(0, retrieved.Count, "Combined search failed");
         }
 
         /// <summary>
@@ -274,7 +265,7 @@ namespace Repositories.Tests
             [UserDataSource(100)]List<User> users)
         {
             // Seed database
-            DbContext.AddRange(users);
+            await DbContext.AddRangeAsync(users);
             await DbContext.SaveChangesAsync();
 
             // Test
@@ -294,7 +285,7 @@ namespace Repositories.Tests
             // And seed database
             projects = SetStaticTestData(projects);
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             List<Project> retrieved = (List<Project>) await Repository.SearchAsync("abc");
@@ -317,12 +308,12 @@ namespace Repositories.Tests
             // And seed database
             projects = SetStaticTestData(projects, users);
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Tests
-            // Id search
-            List<Project> retrieved = (List<Project>)await Repository.SearchAsync("-1");
+            // Name search
+            List<Project> retrieved = (List<Project>)await Repository.SearchAsync("test");
             Assert.AreEqual(0, retrieved.Count);
         }
 
@@ -342,24 +333,20 @@ namespace Repositories.Tests
             // And seed database
             projects = SetStaticTestData(projects, users);
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Tests
-            // Id search
-            List<Project> retrieved = (List<Project>)await Repository.SearchAsync("1", 0, 1);
-            Assert.AreEqual(1, retrieved.Count, "Id search failed");
-
             // Name search
-            retrieved = (List<Project>)await Repository.SearchAsync("abc", 10, 10);
+            List<Project> retrieved = (List<Project>)await Repository.SearchAsync("exName", 10, 10);
             Assert.AreEqual(10, retrieved.Count, "Name search failed");
 
             // Description search
-            retrieved = (List<Project>)await Repository.SearchAsync("def", 10, 10);
+            retrieved = (List<Project>)await Repository.SearchAsync("defex", 10, 10);
             Assert.AreEqual(10, retrieved.Count, "Description search failed");
 
             // Short Description search
-            retrieved = (List<Project>)await Repository.SearchAsync("ghij", 10, 10);
+            retrieved = (List<Project>)await Repository.SearchAsync("ghijex", 10, 10);
             Assert.AreEqual(10, retrieved.Count, "Short Description search failed");
 
             // Uri search
@@ -367,12 +354,12 @@ namespace Repositories.Tests
             Assert.AreEqual(10, retrieved.Count, "Uri search failed");
 
             // User name search
-            retrieved = (List<Project>)await Repository.SearchAsync("xyz", 10, 10);
+            retrieved = (List<Project>)await Repository.SearchAsync("xyzex", 10, 10);
             Assert.AreEqual(10, retrieved.Count, "User name search failed");
 
             // Combined search
             retrieved = (List<Project>)await Repository.SearchAsync("ex", 10, 40);
-            Assert.AreEqual(40, retrieved.Count, "Combined search failed");
+            Assert.AreEqual(0, retrieved.Count, "Combined search failed");
         }
 
         /// <summary>
@@ -391,7 +378,7 @@ namespace Repositories.Tests
             // And seed database
             projects = SetStaticTestData(projects, users);
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Tests
@@ -415,7 +402,7 @@ namespace Repositories.Tests
             // And seed database
             projects = SetStaticTestData(projects, users);
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Tests
@@ -439,7 +426,7 @@ namespace Repositories.Tests
             // And seed database
             projects = SetStaticTestData(projects, users);
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Tests
@@ -485,7 +472,7 @@ namespace Repositories.Tests
                 }
             }
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Testing
@@ -603,7 +590,7 @@ namespace Repositories.Tests
                 }
             }
 
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Testing
@@ -627,7 +614,7 @@ namespace Repositories.Tests
             // Seeding
             projects = SetStaticTestData(projects, users);
             
-            DbContext.AddRange(projects);
+            await DbContext.AddRangeAsync(projects);
             await DbContext.SaveChangesAsync();
 
             // Testing

--- a/Repositories/ProjectRepository.cs
+++ b/Repositories/ProjectRepository.cs
@@ -286,7 +286,8 @@ namespace Repositories
                 project.Description,
                 project.ShortDescription,
                 project.Uri,
-                project.User.Name
+                project.User.Name,
+                project.Id.ToString()
             }
             .Any(text => regex.IsMatch(text));
         }
@@ -305,6 +306,7 @@ namespace Repositories
                             p.Description.Contains(query) ||
                             p.ShortDescription.Contains(query) ||
                             p.Uri.Contains(query) ||
+                            p.Id.ToString().Equals(query) ||
                             p.User.Name.Contains(query));
         }
     }

--- a/Repositories/ProjectRepository.cs
+++ b/Repositories/ProjectRepository.cs
@@ -23,11 +23,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Repositories
 {
-
     public interface IProjectRepository : IRepository<Project>
     {
 
@@ -53,7 +53,6 @@ namespace Repositories
         Task<int> SearchCountAsync(string query, bool? highlighted = null);
 
         Task<Project> FindWithUserAndCollaboratorsAsync(int id);
-
     }
 
     public class ProjectRepository : Repository<Project>, IProjectRepository
@@ -78,6 +77,7 @@ namespace Repositories
             }
             return project;
         }
+
         /// <summary>
         /// Redact user email from the Projects in the list.
         /// Email will only be redacted if isPublic setting is set to false.
@@ -142,14 +142,10 @@ namespace Repositories
                                                                              h.EndDate == null)
                                                                  .Select(h => h.ProjectId)
                                                                  .ToList();
-                if(highlighted.Value)
-                {
-                    queryable = queryable.Where(p => highlightedQueryable.Contains(p.Id));
-                } else
-                {
-                    queryable = queryable.Where(p => !highlightedQueryable.Contains(p.Id));
-                }
+
+                queryable = queryable.Where(p => highlightedQueryable.Contains(p.Id) == highlighted.Value);
             }
+
             if(orderBy != null)
             {
                 if(orderByAsc)
@@ -160,6 +156,7 @@ namespace Repositories
                     queryable = queryable.OrderByDescending(orderBy);
                 }
             }
+
             if(skip.HasValue) queryable = queryable.Skip(skip.Value);
             if(take.HasValue) queryable = queryable.Take(take.Value);
             return queryable;
@@ -182,8 +179,7 @@ namespace Repositories
             bool? highlighted = null
             )
         {
-            IQueryable<Project> queryable = DbSet
-                .Include(p => p.User);
+            IQueryable<Project> queryable = DbSet.Include(p => p.User);
             queryable = ApplyFilters(queryable, skip, take, orderBy, orderByAsc, highlighted);
 
             List<Project> projects = await queryable.ToListAsync();
@@ -197,9 +193,7 @@ namespace Repositories
         /// <returns>The amount of projects matching the filters</returns>
         public virtual async Task<int> CountAsync(bool? highlighted = null)
         {
-            IQueryable<Project> queryable = DbSet;
-            queryable = ApplyFilters(queryable, null, null, null, true, highlighted);
-            return await queryable.CountAsync();
+            return await ApplyFilters(DbSet, null, null, null, true, highlighted).CountAsync();
         }
 
         /// <summary>
@@ -221,18 +215,8 @@ namespace Repositories
             bool? highlighted = null
         )
         {
-            IQueryable<Project> queryable = DbSet
-                                            .Include(p => p.User)
-                                            .Where(p =>
-                                                       p.Name.Contains(query) ||
-                                                       p.Description.Contains(query) ||
-                                                       p.ShortDescription.Contains(query) ||
-                                                       p.Uri.Contains(query) ||
-                                                       p.Id.ToString()
-                                                        .Equals(query) ||
-                                                       p.User.Name.Contains(query));
-            queryable = ApplyFilters(queryable, skip, take, orderBy, orderByAsc, highlighted);
-            return await queryable.ToListAsync();
+            List<Project> result = await ApplyFilters(GetProjectQueryable(query), skip, take, orderBy, orderByAsc, highlighted).ToListAsync();
+            return result.Where(p => ProjectContainsQuery(p, query)).ToList();
         }
 
         /// <summary>
@@ -243,18 +227,7 @@ namespace Repositories
         /// <returns>The amount of projects matching the filters</returns>
         public virtual async Task<int> SearchCountAsync(string query, bool? highlighted = null)
         {
-            IQueryable<Project> queryable = DbSet
-                                            .Include(p => p.User)
-                                            .Where(p =>
-                                                       p.Name.Contains(query) ||
-                                                       p.Description.Contains(query) ||
-                                                       p.ShortDescription.Contains(query) ||
-                                                       p.Uri.Contains(query) ||
-                                                       p.Id.ToString()
-                                                        .Equals(query) ||
-                                                       p.User.Name.Contains(query));
-            queryable = ApplyFilters(queryable, null, null, null, true, highlighted);
-            return await queryable.CountAsync();
+            return await ApplyFilters(GetProjectQueryable(query), null, null, null, true, highlighted).CountAsync();
         }
 
         /// <summary>
@@ -293,12 +266,46 @@ namespace Repositories
 
                 DbContext.Entry(entity.User)
                          .State = EntityState.Unchanged;
-
             }
 
             DbSet.Update(entity);
         }
 
-    }
+        /// <summary>
+        /// Checks if any of the searchable fields of the project passed contains the provided query.
+        /// </summary>
+        /// <param name="project">A Project to search in</param>
+        /// <param name="query">The query to search in the project's searchable fields.</param>
+        /// <returns>A boolean representing whether or not the passed query was found in the searchable fields of the provided project.</returns>
+        private static bool ProjectContainsQuery(Project project, string query)
+        {
+            Regex regex = new Regex(@$"\b{query}\b", RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            return new List<string>()
+            {
+                project.Name,
+                project.Description,
+                project.ShortDescription,
+                project.Uri,
+                project.User.Name
+            }
+            .Any(text => regex.IsMatch(text));
+        }
 
+        /// <summary>
+        /// Get the project queryable which contains the provided query.
+        /// </summary>
+        /// <param name="query">A string to search in the project's fields.</param>
+        /// <returns>The filtered IQueryable including the project user.</returns>
+        private IQueryable<Project> GetProjectQueryable(string query)
+        {
+            return DbSet
+                    .Include(p => p.User)
+                    .Where(p =>
+                            p.Name.Contains(query) ||
+                            p.Description.Contains(query) ||
+                            p.ShortDescription.Contains(query) ||
+                            p.Uri.Contains(query) ||
+                            p.User.Name.Contains(query));
+        }
+    }
 }


### PR DESCRIPTION
## Description
- Matching only whole strings on project search
- Extracted some duplicating code to new helper methods in the `ProjectRepository`
- Updated and improved some of the tests of the  `ProjectRepository`

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I did not update API Controllers, if I did, I added/changed Postman tests
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce
1. Search a project on the overview page
2. Only projects which contain the whole query in the searchable project fields (Name, ShortDescription, Description, Id, Uri, User Name) should be present

## Link to issue

Closes: #202 
