### PR TITLE
Fix #200 where swagger used the wrong IP to retrieve well-known info

### DIFF
--- a/API/Configuration/Config.cs
+++ b/API/Configuration/Config.cs
@@ -118,6 +118,16 @@ namespace API.Configuration
         [Required]
         [Url]
         public string IdentityUrl { get; set; }
+        /// <summary>
+        ///     Gets or sets the Development identity URL.
+        /// This is used mostly to fix docker environments.
+        /// </summary>
+        /// <value>
+        ///     The identity URL.
+        /// </value>
+        [Required]
+        [Url]
+        public string DevelopmentIdentityUrl { get; set; }
     }
 
     /// <summary>

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -44,11 +44,13 @@ using System.Threading.Tasks;
 
 namespace API
 {
+
     /// <summary>
     ///     Startup file
     /// </summary>
     public class Startup
     {
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Startup"/> class.
         /// </summary>
@@ -104,80 +106,91 @@ namespace API
             services.AddAuthorization(o =>
             {
                 o.AddPolicy(nameof(Defaults.Scopes.HighlightRead),
-                    policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.HighlightRead))));
+                            policy => policy.Requirements.Add(
+                                new ScopeRequirement(nameof(Defaults.Scopes.HighlightRead))));
                 o.AddPolicy(nameof(Defaults.Scopes.HighlightWrite),
-                    policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.HighlightWrite))));
+                            policy => policy.Requirements.Add(
+                                new ScopeRequirement(nameof(Defaults.Scopes.HighlightWrite))));
 
                 o.AddPolicy(nameof(Defaults.Scopes.ProjectRead),
-                    policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.ProjectRead))));
+                            policy => policy.Requirements.Add(
+                                new ScopeRequirement(nameof(Defaults.Scopes.ProjectRead))));
                 o.AddPolicy(nameof(Defaults.Scopes.ProjectWrite),
-                    policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.ProjectWrite))));
+                            policy => policy.Requirements.Add(
+                                new ScopeRequirement(nameof(Defaults.Scopes.ProjectWrite))));
 
                 o.AddPolicy(nameof(Defaults.Scopes.UserRead),
-                    policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.UserRead))));
+                            policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.UserRead))));
                 o.AddPolicy(nameof(Defaults.Scopes.UserWrite),
-                    policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.UserWrite))));
+                            policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.UserWrite))));
 
                 o.AddPolicy(nameof(Defaults.Scopes.RoleRead),
-                    policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.RoleRead))));
+                            policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.RoleRead))));
                 o.AddPolicy(nameof(Defaults.Scopes.RoleWrite),
-                    policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.RoleWrite))));
+                            policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.RoleWrite))));
 
                 o.AddPolicy(nameof(Defaults.Scopes.EmbedRead),
-                    policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.EmbedRead))));
+                            policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.EmbedRead))));
                 o.AddPolicy(nameof(Defaults.Scopes.EmbedWrite),
-                    policy => policy.Requirements.Add(new ScopeRequirement(nameof(Defaults.Scopes.EmbedWrite))));
+                            policy => policy.Requirements.Add(
+                                new ScopeRequirement(nameof(Defaults.Scopes.EmbedWrite))));
             });
 
             services.AddCors();
             services.AddControllersWithViews()
                     .AddFluentValidation(c => c.RegisterValidatorsFromAssemblyContaining<Startup>())
-                    .AddNewtonsoftJson(options => options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore)
+                    .AddNewtonsoftJson(options => options.SerializerSettings.ReferenceLoopHandling =
+                                                      Newtonsoft.Json.ReferenceLoopHandling.Ignore)
                 ;
 
             services.AddSwaggerGen(o =>
             {
                 o.OperationFilter<DefaultOperationFilter>();
                 o.SwaggerDoc("v1",
-                    new OpenApiInfo
-                    {
-                        Title = "Dex API",
-                        Version = "v1",
-                        Description = "Dex API Swagger surface. DeX provides a platform for students, teachers and employees to share and work on projects and ideas. Find, create, share and work on projects and ideas on DeX",
-                        License = new OpenApiLicense
-                        {
-                            Name = "GNU Lesser General Public License v3.0",
-                            Url = new Uri("https://www.gnu.org/licenses/lgpl-3.0.txt")
-                        }
-                    });
-                o.IncludeXmlComments($"{AppDomain.CurrentDomain.BaseDirectory}{typeof(Startup).Namespace}.xml", true);
-                Uri authorizationUrl = Environment.IsDevelopment() ? new Uri(Config.IdentityServer.DevelopmentIdentityUrl + "/connect/authorize") : new Uri(Config.IdentityServer.IdentityUrl + "/connect/authorize");
-                
-                o.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
-                {
-                    Type = SecuritySchemeType.OAuth2,
-                    Flows = new OpenApiOAuthFlows
-                            {
-                                Implicit = new OpenApiOAuthFlow
+                             new OpenApiInfo
+                             {
+                                 Title = "Dex API",
+                                 Version = "v1",
+                                 Description =
+                                     "Dex API Swagger surface. DeX provides a platform for students, teachers and employees to share and work on projects and ideas. Find, create, share and work on projects and ideas on DeX",
+                                 License = new OpenApiLicense
                                            {
-                                               AuthorizationUrl = authorizationUrl,
-                                               Scopes = new Dictionary<string, string>
-                                                        {
-                                                            { "dex-api", "Resource scope" },
-                                                        }
+                                               Name = "GNU Lesser General Public License v3.0",
+                                               Url = new Uri("https://www.gnu.org/licenses/lgpl-3.0.txt")
                                            }
-                            }
-                });
+                             });
+                o.IncludeXmlComments($"{AppDomain.CurrentDomain.BaseDirectory}{typeof(Startup).Namespace}.xml", true);
+
+                o.AddSecurityDefinition("oauth2",
+                                        new OpenApiSecurityScheme
+                                        {
+                                            Type = SecuritySchemeType.OAuth2,
+                                            Flows = new OpenApiOAuthFlows
+                                                    {
+                                                        Implicit = new OpenApiOAuthFlow
+                                                                   {
+                                                                       AuthorizationUrl = GetAuthorizationUrl(),
+                                                                       Scopes = new Dictionary<string, string>
+                                                                           {
+                                                                               {"dex-api", "Resource scope"},
+                                                                           }
+                                                                   }
+                                                    }
+                                        });
                 o.AddSecurityRequirement(new OpenApiSecurityRequirement
-                {
-                    {
-                        new OpenApiSecurityScheme
-                        {
-                            Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "oauth2" }
-                        },
-                        new[] { "" }
-                    }
-                });
+                                         {
+                                             {
+                                                 new OpenApiSecurityScheme
+                                                 {
+                                                     Reference = new OpenApiReference
+                                                                 {
+                                                                     Type = ReferenceType.SecurityScheme,
+                                                                     Id = "oauth2"
+                                                                 }
+                                                 },
+                                                 new[] {""}
+                                             }
+                                         });
             });
 
             // Add application services.
@@ -194,7 +207,7 @@ namespace API
         /// <param name="env">The env.</param>
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            UpdateDatabase(app,env);
+            UpdateDatabase(app, env);
             if(env.IsDevelopment())
             {
                 //app.UseBrowserLink();
@@ -233,50 +246,57 @@ namespace API
 
             //UserInfo
             app.UseWhen(context =>
-                context.User.Identities.Any(i => i.IsAuthenticated), appBuilder =>
-                {
-                    appBuilder.Use(async (context, next) =>
-                    {
-                        DbContext dbContext = context.RequestServices.GetService<DbContext>();
-                        IUserService userService =
-                            context.RequestServices.GetService<IUserService>();
-                        string identityId = "";
-                        try
+                            context.User.Identities.Any(i => i.IsAuthenticated),
+                        appBuilder =>
                         {
-                            identityId = context.User.GetIdentityId(context);
-                        } catch(UnauthorizedAccessException e)
-                        {
-                            Log.Logger.Error(e, "User is not authorized.");
-                            await next();
-                        }
-                        if(await userService.GetUserByIdentityIdAsync(identityId).ConfigureAwait(false) == null)
-                        {
-                            IRoleService roleService = context.RequestServices.GetService<IRoleService>();
-                            Role registeredUserRole = (await roleService.GetAll()).FirstOrDefault(i => i.Name == nameof(Defaults.Roles.RegisteredUser));
-
-                            User newUser = context.GetUserInformation(Config);
-                            if(newUser == null)
+                            appBuilder.Use(async (context, next) =>
                             {
-                                // Then it probably belongs swagger so we set the username as developer.
-                                newUser = new User()
+                                DbContext dbContext = context.RequestServices.GetService<DbContext>();
+                                IUserService userService =
+                                    context.RequestServices.GetService<IUserService>();
+                                string identityId = "";
+                                try
                                 {
-                                    Name = "Developer",
-                                    Email = "Developer@DEX.com",
-                                    IdentityId = identityId,
-                                    Role = registeredUserRole
-                                };
-                                userService.Add(newUser);
-                            } else
-                            {
-                                newUser.Role = registeredUserRole;
-                                userService.Add(newUser);
-                            }
-                            await dbContext.SaveChangesAsync().ConfigureAwait(false);
-                        }
+                                    identityId = context.User.GetIdentityId(context);
+                                } catch(UnauthorizedAccessException e)
+                                {
+                                    Log.Logger.Error(e, "User is not authorized.");
+                                    await next();
+                                }
+                                if(await userService.GetUserByIdentityIdAsync(identityId)
+                                                    .ConfigureAwait(false) ==
+                                   null)
+                                {
+                                    IRoleService roleService = context.RequestServices.GetService<IRoleService>();
+                                    Role registeredUserRole =
+                                        (await roleService.GetAll()).FirstOrDefault(
+                                            i => i.Name == nameof(Defaults.Roles.RegisteredUser));
 
-                        await next().ConfigureAwait(false);
-                    });
-                });
+                                    User newUser = context.GetUserInformation(Config);
+                                    if(newUser == null)
+                                    {
+                                        // Then it probably belongs swagger so we set the username as developer.
+                                        newUser = new User()
+                                                  {
+                                                      Name = "Developer",
+                                                      Email = "Developer@DEX.com",
+                                                      IdentityId = identityId,
+                                                      Role = registeredUserRole
+                                                  };
+                                        userService.Add(newUser);
+                                    } else
+                                    {
+                                        newUser.Role = registeredUserRole;
+                                        userService.Add(newUser);
+                                    }
+                                    await dbContext.SaveChangesAsync()
+                                                   .ConfigureAwait(false);
+                                }
+
+                                await next()
+                                    .ConfigureAwait(false);
+                            });
+                        });
 
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
 
@@ -349,8 +369,23 @@ namespace API
                     context.Highlight.AddRange(Seed.SeedHighlights(projects));
                     context.SaveChanges();
                 }
+
                 // TODO seed embedded projects
             }
         }
+
+        /// <summary>
+        ///     Depending on the environment, will return authorization url based on development identity url or identity url
+        /// </summary>
+        private Uri GetAuthorizationUrl()
+        {
+            if(Environment.IsDevelopment())
+            {
+                return new Uri(Config.IdentityServer.DevelopmentIdentityUrl + "/connect/authorize");
+            }
+            return new Uri(Config.IdentityServer.IdentityUrl + "/connect/authorize");
+        }
+
     }
+
 }

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -151,20 +151,22 @@ namespace API
                         }
                     });
                 o.IncludeXmlComments($"{AppDomain.CurrentDomain.BaseDirectory}{typeof(Startup).Namespace}.xml", true);
+                Uri authorizationUrl = Environment.IsDevelopment() ? new Uri(Config.IdentityServer.DevelopmentIdentityUrl + "/connect/authorize") : new Uri(Config.IdentityServer.IdentityUrl + "/connect/authorize");
+                
                 o.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
                 {
                     Type = SecuritySchemeType.OAuth2,
                     Flows = new OpenApiOAuthFlows
-                    {
-                        Implicit = new OpenApiOAuthFlow
-                        {
-                            AuthorizationUrl = new Uri(Config.IdentityServer.IdentityUrl + "/connect/authorize"),
-                            Scopes = new Dictionary<string, string>
                             {
-                                { "dex-api", "Resource scope" },
+                                Implicit = new OpenApiOAuthFlow
+                                           {
+                                               AuthorizationUrl = authorizationUrl,
+                                               Scopes = new Dictionary<string, string>
+                                                        {
+                                                            { "dex-api", "Resource scope" },
+                                                        }
+                                           }
                             }
-                        }
-                    }
                 });
                 o.AddSecurityRequirement(new OpenApiSecurityRequirement
                 {

--- a/API/appsettings.Development.json
+++ b/API/appsettings.Development.json
@@ -10,7 +10,8 @@
             "ClientSecret": "Q!P5kqCukQBe77cVk5dqWHqx#8FaC2fDN&bstyxrHtw%5R@3Cz*Z"
         },
         "IdentityServer": {
-            "IdentityUrl": "https://localhost:5005"
+            "IdentityUrl": "https://localhost:5005",
+            "DevelopmentIdentityUrl":  "https://localhost:5005"
         },
         "Swagger": {
             "ClientId":  "Swagger-UI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-### Security  
-  
-  
+- Fixed issue where swagger authorization was not working when running in docker-compose - [#200](https://github.com/DigitalExcellence/dex-backend/issues/200)
+
+### Security
+
+
 
 ## Release v.0.7.0-beta - 09-10-2020
 
@@ -74,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added error tracking and monitoring with Sentry - [#136](https://github.com/DigitalExcellence/dex-backend/issues/136)
 - Support for fontys login - [#66](https://github.com/DigitalExcellence/dex-backend/issues/66)
 - Added flag to indicate if email is public, show redacted email if not public - [#138](https://github.com/DigitalExcellence/dex-backend/issues/138)
-- Added Integration tests using Postman, also tests different access control levels - [#40](https://github.com/DigitalExcellence/dex-backend/issues/40) 
+- Added Integration tests using Postman, also tests different access control levels - [#40](https://github.com/DigitalExcellence/dex-backend/issues/40)
 - Added an endpoint to get highlights by a project identifier - [#174](https://github.com/DigitalExcellence/dex-backend/issues/174)
 - Automated the deployment to our environments - [#60](https://github.com/DigitalExcellence/dex-backend/issues/60)
 - Added docker compose to get the backend services running locally - [#179](https://github.com/DigitalExcellence/dex-backend/issues/179)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,10 @@ services:
     build:
       context: .
       dockerfile: Data/Dockerfile
-    environment: 
+    environment:
       - MSSQL_SA_PASSWORD=Dexcelence!1
     networks:
       mssql-network:
-        ipv4_address: 172.16.238.2
 
   identity:
     build:
@@ -17,40 +16,38 @@ services:
       dockerfile: IdentityServer/Dockerfile.dev
     depends_on:
       - db
-    environment: 
+    environment:
       - ConnectionStrings__DefaultConnection=Server=db;Database=identity;User=sa;Password=Dexcelence!1;
-      - App__Self__IssuerUri=https://172.16.238.3:5004
-      - App__Api__DeXApiUrl=https://172.16.238.4
-      - ASPNETCORE_URLS=https://+;
+      - App__Self__IssuerUri=https://identity:5005
+      - App__Api__DeXApiUrl=https://api:5001
+      - ASPNETCORE_URLS=http://+:5004;https://+:5005;
       - ASPNETCORE_HTTPS_PORT=5005
       - ASPNETCORE_Kestrel__Certificates__Default__Password=W64x4AD8dNj9kImdX3tayS
       - ASPNETCORE_Kestrel__Certificates__Default__Path=/app/dex-identity.pfx
-    networks: 
+    networks:
       mssql-network:
-        ipv4_address: 172.16.238.3
     ports:
-      - 5004:80
-      - 5005:443
-    
+      - 5004:5004
+      - 5005:5005
+
   api:
     build:
       context: .
       dockerfile: API/Dockerfile.dev
     depends_on:
       - db
-    environment: 
+    environment:
       - ConnectionStrings__DefaultConnection=Server=db;Database=master;User=sa;Password=Dexcelence!1;
-      - App__IdentityServer__IdentityUrl=https://172.16.238.3
-      - ASPNETCORE_URLS=https://+;
+      - App__IdentityServer__IdentityUrl=http://identity:5004
+      - ASPNETCORE_URLS=http://+:5000;https://+:5001;
       - ASPNETCORE_HTTPS_PORT=5001
       - ASPNETCORE_Kestrel__Certificates__Default__Password=xI90DrNea7M6UJFNDwip6t
       - ASPNETCORE_Kestrel__Certificates__Default__Path=/app/dex-api.pfx
     networks:
       mssql-network:
-        ipv4_address: 172.16.238.4
     ports:
-      - 5000:80
-      - 5001:443
+      - 5000:5000
+      - 5001:5001
 
 networks:
   mssql-network:


### PR DESCRIPTION
## Description

Swagger auth was using the internal docker IP. This won't work as you need to reference localhost:5005. 
Identity and API also weren't running on 5001/5000 and 5004/5005 as aspnetcore_urls were not referencing the ports correctly. 
In addition to that, I removed the part where direct ip's were referenced instead of service names. This change makes things easier to follow and less likely to break in the future, let Docker do it's DNS magic to resolve the IP address from the container.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I did not update API Controllers, if I did, I added/changed Postman tests
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.
These steps will be used during release testing.

1. Run the backend with docker-compose up --build
2. Use the green lock in swagger to authorize yourself
3. Try the user-get endpoint and see if everything works fine.

## Link to issue

Closes: #200 
