### PR TITLE
Improve performance when retrieving a project with collaborators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue where unused project icons where left in the database & File System - [#271](https://github.com/DigitalExcellence/dex-backend/issues/271)
 - Refactored Postman CLI files to make them work from Postman folder. - [#304](https://github.com/DigitalExcellence/dex-backend/issues/304)
 - Fixed issue where searching for a project did not include the project icon. - [#307](https://github.com/DigitalExcellence/dex-backend/issues/307)
+- Fixes issue where retrieving projects performed badly due to large amount of collaborators. - [#331](https://github.com/DigitalExcellence/dex-backend/issues/331)
 
 ### Security
 

--- a/Repositories/ProjectRepository.cs
+++ b/Repositories/ProjectRepository.cs
@@ -116,6 +116,7 @@ namespace Repositories
                 project.Collaborators = await GetDbSet<Collaborator>()
                                               .Where(p => p.ProjectId == project.Id)
                                               .ToListAsync();
+                project.User = RedactUser(project.User);
             }
             return await queryableProjects.ToListAsync();
         }

--- a/Repositories/ProjectRepository.cs
+++ b/Repositories/ProjectRepository.cs
@@ -252,6 +252,7 @@ namespace Repositories
         /// </returns>
         private User RedactUser(User user)
         {
+            if(user == null) return null;
             if(user.IsPublic == false)
             {
                 user.Email = Defaults.Privacy.RedactedEmail;

--- a/Repositories/ProjectRepository.cs
+++ b/Repositories/ProjectRepository.cs
@@ -105,6 +105,7 @@ namespace Repositories
         )
         {
             IQueryable<Project> queryableProjects = GetDbSet<Project>()
+                                                    .Include(u => u.User)
                                                     .Include(p => p.ProjectIcon)
                                                     .Include(p => p.CallToAction);
             queryableProjects = ApplyFilters(queryableProjects, skip, take, orderBy, orderByAsc, highlighted);
@@ -115,9 +116,6 @@ namespace Repositories
                 project.Collaborators = await GetDbSet<Collaborator>()
                                               .Where(p => p.ProjectId == project.Id)
                                               .ToListAsync();
-                project.User = RedactUser(await GetDbSet<User>()
-                                                .Where(p => p.Id == project.UserId)
-                                                .FirstOrDefaultAsync());
             }
             return await queryableProjects.ToListAsync();
         }

--- a/Repositories/ProjectRepository.cs
+++ b/Repositories/ProjectRepository.cs
@@ -16,7 +16,6 @@
 */
 
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Query;
 using Models;
 using Models.Defaults;
 using Repositories.Base;
@@ -29,6 +28,7 @@ using System.Threading.Tasks;
 
 namespace Repositories
 {
+
     public interface IProjectRepository : IRepository<Project>
     {
 
@@ -38,7 +38,7 @@ namespace Repositories
             Expression<Func<Project, object>> orderBy = null,
             bool orderByAsc = true,
             bool? highlighted = null
-            );
+        );
 
         Task<int> CountAsync(bool? highlighted = null);
 
@@ -54,6 +54,7 @@ namespace Repositories
         Task<int> SearchCountAsync(string query, bool? highlighted = null);
 
         Task<Project> FindWithUserAndCollaboratorsAsync(int id);
+
     }
 
     public class ProjectRepository : Repository<Project>, IProjectRepository
@@ -62,11 +63,174 @@ namespace Repositories
         public ProjectRepository(DbContext dbContext) : base(dbContext) { }
 
         /// <summary>
-        /// Redact user email from the Project if isPublic setting is set to false
+        ///     Find the project async by project id
+        /// </summary>
+        /// <param name="id">The identifier.</param>
+        /// <returns>
+        ///     Project with possibly redacted email
+        /// </returns>
+        public override async Task<Project> FindAsync(int id)
+        {
+            Project project = await GetDbSet<Project>()
+                                    .Where(s => s.Id == id)
+                                    .Include(p => p.ProjectIcon)
+                                    .Include(p => p.CallToAction)
+                                    .SingleOrDefaultAsync();
+
+            if(project != null)
+            {
+                project.Collaborators = await GetDbSet<Collaborator>()
+                                              .Where(p => p.ProjectId == project.Id)
+                                              .ToListAsync();
+            }
+
+            return RedactUser(project);
+        }
+
+        /// <summary>
+        ///     Get the projects in the database
+        /// </summary>
+        /// <param name="skip">The number of projects to skip</param>
+        /// <param name="take">The number of projects to return</param>
+        /// <param name="orderBy">The property to order the projects by</param>
+        /// <param name="orderByAsc">The order direction (True: asc, False: desc)</param>
+        /// <param name="highlighted">Filter highlighted projects</param>
+        /// <returns>The projects filtered by the parameters</returns>
+        public virtual async Task<List<Project>> GetAllWithUsersAndCollaboratorsAsync(
+            int? skip = null,
+            int? take = null,
+            Expression<Func<Project, object>> orderBy = null,
+            bool orderByAsc = true,
+            bool? highlighted = null
+        )
+        {
+            IQueryable<Project> queryableProjects = GetDbSet<Project>()
+                                                    .Include(p => p.ProjectIcon)
+                                                    .Include(p => p.CallToAction);
+            queryableProjects = ApplyFilters(queryableProjects, skip, take, orderBy, orderByAsc, highlighted);
+
+
+            foreach(Project project in queryableProjects)
+            {
+                project.Collaborators = await GetDbSet<Collaborator>()
+                                              .Where(p => p.ProjectId == project.Id)
+                                              .ToListAsync();
+                project.User = RedactUser(await GetDbSet<User>()
+                                                .Where(p => p.Id == project.UserId)
+                                                .FirstOrDefaultAsync());
+            }
+            return await queryableProjects.ToListAsync();
+        }
+
+        /// <summary>
+        ///     Count the amount of projects matching the filters
+        /// </summary>
+        /// <param name="highlighted">The highlighted filter</param>
+        /// <returns>The amount of projects matching the filters</returns>
+        public virtual async Task<int> CountAsync(bool? highlighted = null)
+        {
+            return await ApplyFilters(DbSet, null, null, null, true, highlighted)
+                       .CountAsync();
+        }
+
+        /// <summary>
+        ///     Search the database for projects matching the search query and parameters
+        /// </summary>
+        /// <param name="query">The search query</param>
+        /// <param name="skip">The number of projects to skip</param>
+        /// <param name="take">The number of projects to return</param>
+        /// <param name="orderBy">The property to order the projects by</param>
+        /// <param name="orderByAsc">The order direction (True: asc, False: desc)</param>
+        /// <param name="highlighted">Filter highlighted projects</param>
+        /// <returns>The projects matching the search query and parameters</returns>
+        public virtual async Task<IEnumerable<Project>> SearchAsync(
+            string query,
+            int? skip = null,
+            int? take = null,
+            Expression<Func<Project, object>> orderBy = null,
+            bool orderByAsc = true,
+            bool? highlighted = null
+        )
+        {
+            List<Project> result =
+                await ApplyFilters(GetProjectQueryable(query), skip, take, orderBy, orderByAsc, highlighted)
+                    .ToListAsync();
+            return result.Where(p => ProjectContainsQuery(p, query))
+                         .ToList();
+        }
+
+        /// <summary>
+        ///     Count the amount of projects matching the filters and the search query
+        /// </summary>
+        /// <param name="query">The search query</param>
+        /// <param name="highlighted">The highlighted filter</param>
+        /// <returns>The amount of projects matching the filters</returns>
+        public virtual async Task<int> SearchCountAsync(string query, bool? highlighted = null)
+        {
+            return await ApplyFilters(GetProjectQueryable(query), null, null, null, true, highlighted)
+                       .CountAsync();
+        }
+
+        /// <summary>
+        ///     Retrieve project with user and collaborators async.
+        ///     Project will be redacted if user has that setting configured.
+        /// </summary>
+        /// <param name="id">The identifier.</param>
+        /// <returns>
+        ///     Possibly redacted Project object with user and collaborators
+        /// </returns>
+        public async Task<Project> FindWithUserAndCollaboratorsAsync(int id)
+        {
+            Project project = await GetDbSet<Project>()
+                                    .Include(p => p.User)
+                                    .Include(p => p.ProjectIcon)
+                                    .Include(p => p.CallToAction)
+                                    .Where(p => p.Id == id)
+                                    .FirstOrDefaultAsync();
+            if(project != null)
+            {
+                project.Collaborators = await GetDbSet<Collaborator>()
+                                              .Where(p => p.ProjectId == project.Id)
+                                              .ToListAsync();
+            }
+
+            return RedactUser(project);
+        }
+
+        /// <summary>
+        ///     Updates the specified entity excluding the user object.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        public override void Update(Project entity)
+        {
+            entity = UpdateUpdatedField(entity);
+
+            DbSet.Attach(entity);
+            if(entity.User != null)
+            {
+                DbContext.Entry(entity.User)
+                         .Property(x => x.Email)
+                         .IsModified = false;
+
+                DbContext.Entry(entity.User)
+                         .State = EntityState.Unchanged;
+            }
+
+            if(entity.ProjectIcon == null)
+            {
+                DbContext.Entry(entity)
+                         .Entity.ProjectIconId = null;
+            }
+
+            DbSet.Update(entity);
+        }
+
+        /// <summary>
+        ///     Redact user email from the Project if isPublic setting is set to false
         /// </summary>
         /// <param name="project">The project.</param>
         /// <returns>
-        /// Project with possibly redacted email depending on setting
+        ///     Project with possibly redacted email depending on setting
         /// </returns>
         private Project RedactUser(Project project)
         {
@@ -80,12 +244,28 @@ namespace Repositories
         }
 
         /// <summary>
-        /// Redact user email from the Projects in the list.
-        /// Email will only be redacted if isPublic setting is set to false.
+        ///     Redact user email from the User if isPublic setting is set to false
+        /// </summary>
+        /// <param name="user">The user.</param>
+        /// <returns>
+        ///     User with possibly redacted email depending on setting
+        /// </returns>
+        private User RedactUser(User user)
+        {
+            if(user.IsPublic == false)
+            {
+                user.Email = Defaults.Privacy.RedactedEmail;
+            }
+            return user;
+        }
+
+        /// <summary>
+        ///     Redact user email from the Projects in the list.
+        ///     Email will only be redacted if isPublic setting is set to false.
         /// </summary>
         /// <param name="projects">The projects.</param>
         /// <returns>
-        /// List of Projects with possibly redacted email depending on setting
+        ///     List of Projects with possibly redacted email depending on setting
         /// </returns>
         private List<Project> RedactUser(List<Project> projects)
         {
@@ -97,25 +277,7 @@ namespace Repositories
         }
 
         /// <summary>
-        /// Find the project async by project id
-        /// </summary>
-        /// <param name="id">The identifier.</param>
-        /// <returns>
-        /// Project with possibly redacted email
-        /// </returns>
-        public override async Task<Project> FindAsync(int id)
-        {
-            Project project = await GetDbSet<Project>()
-                   .Where(s => s.Id == id)
-                   .Include(p => p.Collaborators)
-                   .Include(p => p.CallToAction)
-                   .SingleOrDefaultAsync();
-
-            return RedactUser(project);
-        }
-
-        /// <summary>
-        /// Apply query parameters and find project based on these filters
+        ///     Apply query parameters and find project based on these filters
         /// </summary>
         /// <param name="queryable">The linq queryable object.</param>
         /// <param name="skip">The amount of objects to skip.</param>
@@ -124,7 +286,7 @@ namespace Repositories
         /// <param name="orderByAsc">if set to <c>true</c> [order by asc].</param>
         /// <param name="highlighted">Boolean if the project should show highlighted.</param>
         /// <returns>
-        /// IQueryable Projects based on the given filters
+        ///     IQueryable Projects based on the given filters
         /// </returns>
         private IQueryable<Project> ApplyFilters(
             IQueryable<Project> queryable,
@@ -133,7 +295,7 @@ namespace Repositories
             Expression<Func<Project, object>> orderBy,
             bool orderByAsc,
             bool? highlighted
-            )
+        )
         {
             if(highlighted.HasValue)
             {
@@ -165,166 +327,50 @@ namespace Repositories
         }
 
         /// <summary>
-        ///     Get the projects in the database
-        /// </summary>
-        /// <param name="skip">The number of projects to skip</param>
-        /// <param name="take">The number of projects to return</param>
-        /// <param name="orderBy">The property to order the projects by</param>
-        /// <param name="orderByAsc">The order direction (True: asc, False: desc)</param>
-        /// <param name="highlighted">Filter highlighted projects</param>
-        /// <returns>The projects filtered by the parameters</returns>
-        public virtual async Task<List<Project>> GetAllWithUsersAndCollaboratorsAsync(
-            int? skip = null,
-            int? take = null,
-            Expression<Func<Project, object>> orderBy = null,
-            bool orderByAsc = true,
-            bool? highlighted = null
-            )
-        {
-            IQueryable<Project> queryable = DbSet
-                                            .Include(p => p.User)
-                                            .Include(p => p.ProjectIcon)
-                                            .Include(p => p.CallToAction)
-                                            .Include(p => p.Collaborators);
-
-            queryable = ApplyFilters(queryable, skip, take, orderBy, orderByAsc, highlighted);
-
-            List<Project> projects = await queryable.ToListAsync();
-            return RedactUser(projects);
-        }
-
-        /// <summary>
-        /// Count the amount of projects matching the filters
-        /// </summary>
-        /// <param name="highlighted">The highlighted filter</param>
-        /// <returns>The amount of projects matching the filters</returns>
-        public virtual async Task<int> CountAsync(bool? highlighted = null)
-        {
-            return await ApplyFilters(DbSet, null, null, null, true, highlighted).CountAsync();
-        }
-
-        /// <summary>
-        ///     Search the database for projects matching the search query and parameters
-        /// </summary>
-        /// <param name="query">The search query</param>
-        /// <param name="skip">The number of projects to skip</param>
-        /// <param name="take">The number of projects to return</param>
-        /// <param name="orderBy">The property to order the projects by</param>
-        /// <param name="orderByAsc">The order direction (True: asc, False: desc)</param>
-        /// <param name="highlighted">Filter highlighted projects</param>
-        /// <returns>The projects matching the search query and parameters</returns>
-        public virtual async Task<IEnumerable<Project>> SearchAsync(
-            string query,
-            int? skip = null,
-            int? take = null,
-            Expression<Func<Project, object>> orderBy = null,
-            bool orderByAsc = true,
-            bool? highlighted = null
-        )
-        {
-            List<Project> result = await ApplyFilters(GetProjectQueryable(query), skip, take, orderBy, orderByAsc, highlighted).ToListAsync();
-            return result.Where(p => ProjectContainsQuery(p, query)).ToList();
-        }
-
-        /// <summary>
-        /// Count the amount of projects matching the filters and the search query
-        /// </summary>
-        /// <param name="query">The search query</param>
-        /// <param name="highlighted">The highlighted filter</param>
-        /// <returns>The amount of projects matching the filters</returns>
-        public virtual async Task<int> SearchCountAsync(string query, bool? highlighted = null)
-        {
-            return await ApplyFilters(GetProjectQueryable(query), null, null, null, true, highlighted).CountAsync();
-        }
-
-        /// <summary>
-        /// Retrieve project with user and collaborators async.
-        /// Project will be redacted if user has that setting configured.
-        /// </summary>
-        /// <param name="id">The identifier.</param>
-        /// <returns>
-        /// Possibly redacted Project object with user and collaborators
-        /// </returns>
-        public async Task<Project> FindWithUserAndCollaboratorsAsync(int id)
-        {
-            Project project = await GetDbSet<Project>()
-                   .Include(p => p.User)
-                   .Include(p => p.Collaborators)
-                   .Include(p => p.ProjectIcon)
-                   .Include(p => p.CallToAction)
-                   .Where(p => p.Id == id)
-                   .FirstOrDefaultAsync();
-
-            return RedactUser(project);
-        }
-
-        /// <summary>
-        /// Updates the specified entity excluding the user object.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        public override void Update(Project entity)
-        {
-            entity = UpdateUpdatedField(entity);
-
-            DbSet.Attach(entity);
-            if(entity.User != null)
-            {
-                DbContext.Entry(entity.User)
-                         .Property(x => x.Email)
-                         .IsModified = false;
-
-                DbContext.Entry(entity.User)
-                         .State = EntityState.Unchanged;
-            }
-
-            if(entity.ProjectIcon == null)
-            {
-                DbContext.Entry(entity)
-                         .Entity.ProjectIconId = null;
-            }
-
-            DbSet.Update(entity);
-        }
-
-        /// <summary>
-        /// Checks if any of the searchable fields of the project passed contains the provided query.
+        ///     Checks if any of the searchable fields of the project passed contains the provided query.
         /// </summary>
         /// <param name="project">A Project to search in</param>
         /// <param name="query">The query to search in the project's searchable fields.</param>
-        /// <returns>A boolean representing whether or not the passed query was found in the searchable fields of the provided project.</returns>
+        /// <returns>
+        ///     A boolean representing whether or not the passed query was found in the searchable fields of the provided
+        ///     project.
+        /// </returns>
         private static bool ProjectContainsQuery(Project project, string query)
         {
             Regex regex = new Regex(@$"\b{query}\b", RegexOptions.Singleline | RegexOptions.IgnoreCase);
-            return new List<string>()
-            {
-                project.Name,
-                project.Description,
-                project.ShortDescription,
-                project.Uri,
-                project.User.Name,
-                project.Id.ToString()
-            }
-            .Any(text => regex.IsMatch(text));
+            return new List<string>
+                   {
+                       project.Name,
+                       project.Description,
+                       project.ShortDescription,
+                       project.Uri,
+                       project.User.Name,
+                       project.Id.ToString()
+                   }
+                .Any(text => regex.IsMatch(text));
         }
 
         /// <summary>
-        /// Get the project queryable which contains the provided query.
+        ///     Get the project queryable which contains the provided query.
         /// </summary>
         /// <param name="query">A string to search in the project's fields.</param>
         /// <returns>The filtered IQueryable including the project user.</returns>
         private IQueryable<Project> GetProjectQueryable(string query)
         {
             return DbSet
-                    .Include(p => p.User)
-                    .Include(i => i.ProjectIcon)
-                    .Include(p => p.CallToAction)
-                    .Where(p =>
-                            p.Name.Contains(query) ||
-                            p.Description.Contains(query) ||
-                            p.ShortDescription.Contains(query) ||
-                            p.Uri.Contains(query) ||
-                            p.Id.ToString().Equals(query) ||
-                            p.User.Name.Contains(query));
+                   .Include(p => p.User)
+                   .Include(i => i.ProjectIcon)
+                   .Include(p => p.CallToAction)
+                   .Where(p =>
+                              p.Name.Contains(query) ||
+                              p.Description.Contains(query) ||
+                              p.ShortDescription.Contains(query) ||
+                              p.Uri.Contains(query) ||
+                              p.Id.ToString()
+                               .Equals(query) ||
+                              p.User.Name.Contains(query));
         }
+
     }
+
 }


### PR DESCRIPTION
## Description

Add Collaborators by performing for each loop instead of joining tables. Joining tables by using Include() caused the query to take sometimes up to 10 times as long. This was an issue as it caused a drastic slow down when retrieving all projects, retrieving project detail, or when searching for projects.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I did not update API Controllers, if I did, I added/changed Postman tests
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.
These steps will be used during release testing.

1. Go to the project overview page
2. Check if it's snappy and more performance compared to on staging

## Link to issue

Closes: #331 
