### PR TITLE
Attribute of ProjectLike rename

### DIFF
--- a/Models/ProjectLike.cs
+++ b/Models/ProjectLike.cs
@@ -10,10 +10,10 @@ namespace Models
     public class ProjectLike
     {
 
-        public ProjectLike(Project likedProject, User creatorOfProject)
+        public ProjectLike(Project likedProject, User projectLiker)
         {
             LikedProject = likedProject;
-            CreatorOfProject = creatorOfProject;
+            ProjectLiker = projectLiker;
             Date = DateTime.Now;
         }
 
@@ -39,12 +39,12 @@ namespace Models
         public Project LikedProject { get; set; }
 
         /// <summary>
-        /// Gets or set the creator of the project.
+        /// Gets or set the project liker.
         /// </summary>
         /// <value>
-        /// The User instance.
+        /// The User instance of the one who likes the project.
         /// </value>
-        public User CreatorOfProject { get; set; }
+        public User ProjectLiker { get; set; }
 
         /// <summary>
         /// Gets or sets the user who liked the project.

--- a/Repositories/UserProjectLikeRepository.cs
+++ b/Repositories/UserProjectLikeRepository.cs
@@ -46,7 +46,7 @@ namespace Repositories
             ProjectLike projectToRemove = GetDbSet
                     <ProjectLike>()
                 .SingleOrDefault(project => project.UserId ==
-                                            projectLike.CreatorOfProject.Id &&
+                                            projectLike.ProjectLiker.Id &&
                                             project.LikedProject.Id ==
                                             projectLike.LikedProject.Id);
 
@@ -59,7 +59,7 @@ namespace Repositories
         {
             ProjectLike projectLike = GetDbSet<ProjectLike>()
                 .SingleOrDefault(project =>
-                                     (project.UserId == userId) && project.LikedProject.Id == projectId);
+                                     (project.ProjectLiker.Id == userId) && project.LikedProject.Id == projectId);
 
             if(projectLike != null)
             {


### PR DESCRIPTION
## Description

One of the ProjectLike attributes was named CreatorOfProject which was actually representing the one who likes the project.
I renamed it to ProjectLiker to make it more clear.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I did not update API Controllers, if I did, I added/changed Postman tests
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Postman testing shows that code is working. For the frontend nothing changes.

## Link to issue

Closes: #341
