### PR TITLE
Bugfix/352 dataofficer institution update

### DIFF
--- a/API/Common/AuthorizationHelper.cs
+++ b/API/Common/AuthorizationHelper.cs
@@ -54,10 +54,15 @@ namespace API.Common
         {
             bool hasUserWriteScope = userService.UserHasScope(loggedInUser.IdentityId, scope);
             bool hasCorrectDataOfficerRights =
-                userService.UserHasScope(loggedInUser.IdentityId, dataOfficerScope) &&
-                await userService.HasSameInstitution(loggedInUser.Id, propertyOfUserId);
+                await SameInstitutionAndInstitutionScope(loggedInUser, dataOfficerScope, propertyOfUserId);
             bool isAllowed = hasUserWriteScope || hasCorrectDataOfficerRights;
             return isAllowed;
+        }
+
+        public async Task<bool> SameInstitutionAndInstitutionScope(User loggedInUser, string institutionScope, int propertyOfUserId)
+        {
+            return userService.UserHasScope(loggedInUser.IdentityId, institutionScope) &&
+                   await userService.HasSameInstitution(loggedInUser.Id, propertyOfUserId);
         }
 
     }

--- a/API/Common/AuthorizationHelper.cs
+++ b/API/Common/AuthorizationHelper.cs
@@ -59,6 +59,17 @@ namespace API.Common
             return isAllowed;
         }
 
+        /// <summary>
+        /// This method checks if a user has the same institution, and both should not have null. It
+        /// also checks if the user has the correct institution scope that allows changes in the
+        /// same institution.
+        /// </summary>
+        /// <param name="loggedInUser">The user model of the logged in user.</param>
+        /// <param name="institutionScope">The required scope for accessing this
+        /// endpoint for data officers within the same institution.</param>
+        /// <param name="propertyOfUserId">The id of the user owner of the property
+        /// which the logged in user wants to access.</param>
+        /// <returns>Bool: true if the user is allowed, false if the user is not allowed.</returns>
         public async Task<bool> SameInstitutionAndInstitutionScope(User loggedInUser, string institutionScope, int propertyOfUserId)
         {
             return userService.UserHasScope(loggedInUser.IdentityId, institutionScope) &&

--- a/API/Common/IAuthorizationHelper.cs
+++ b/API/Common/IAuthorizationHelper.cs
@@ -42,6 +42,17 @@ namespace API.Common
                                               string dataOfficerScope,
                                               int propertyOfUserId);
 
+        /// <summary>
+        /// This method checks if a user has the same institution, and both should not have null. It
+        /// also checks if the user has the correct institution scope that allows changes in the
+        /// same institution.
+        /// </summary>
+        /// <param name="loggedInUser">The user model of the logged in user.</param>
+        /// <param name="institutionScope">The required scope for accessing this
+        /// endpoint for data officers within the same institution.</param>
+        /// <param name="propertyOfUserId">The id of the user owner of the property
+        /// which the logged in user wants to access.</param>
+        /// <returns>Bool: true if the user is allowed, false if the user is not allowed.</returns>
         Task<bool> SameInstitutionAndInstitutionScope(User loggedInUser,
                                                       string institutionScope,
                                                       int propertyOfUserId);

--- a/API/Common/IAuthorizationHelper.cs
+++ b/API/Common/IAuthorizationHelper.cs
@@ -42,6 +42,10 @@ namespace API.Common
                                               string dataOfficerScope,
                                               int propertyOfUserId);
 
+        Task<bool> SameInstitutionAndInstitutionScope(User loggedInUser,
+                                                      string institutionScope,
+                                                      int propertyOfUserId);
+
     }
 
 }

--- a/API/Controllers/UserController.cs
+++ b/API/Controllers/UserController.cs
@@ -275,7 +275,7 @@ namespace API.Controllers
                                                 .ConfigureAwait(false);
             bool hasFullAllowance = userService.UserHasScope(currentUser.IdentityId, nameof(Defaults.Scopes.UserWrite));
 
-            // Has institution excluded allowance if it's your own account or if the user has right scope for the same institution.
+            // Has institution excluded allowance if it's your own account or if the user has the right scope for the same institution.
             // In the last case, the institution has to be the same.
             bool hasInstitutionExcludedAllowance = currentUser.Id == userId ||
                                                    await authorizationHelper.SameInstitutionAndInstitutionScope(currentUser,
@@ -293,7 +293,7 @@ namespace API.Controllers
                 return Unauthorized(problem);
             }
 
-            // Roles that have the institution excluded allowance and own account can update everything except the institution id.
+            // Roles that have the institution excluded allowance or it's own account can update everything except the institution id.
             if(hasInstitutionExcludedAllowance)
             {
                 // Check if no institution is specified, and if an institution is specified, this institution can't be

--- a/API/Controllers/UserController.cs
+++ b/API/Controllers/UserController.cs
@@ -20,7 +20,6 @@ using API.Extensions;
 using API.Resources;
 using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Models;
@@ -307,7 +306,7 @@ namespace API.Controllers
                         Detail = "The user has not enough rights to update the institution id",
                         Instance = "DD72C521-1D06-4E11-A0E0-AAE515E7F900"
                     };
-                    return StatusCode(StatusCodes.Status403Forbidden, problem);
+                    return Unauthorized(problem);
                 }
             }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Refactored Postman tests - [#328](https://github.com/DigitalExcellence/dex-backend/issues/328)
+- Resolve update institution id for data officer bug - [#352](https://github.com/DigitalExcellence/dex-backend/compare/bugfix/352-dataofficer-institution-update?expand=1)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Refactored Postman tests - [#328](https://github.com/DigitalExcellence/dex-backend/issues/328)
-- Resolve update institution id for data officer bug - [#352](https://github.com/DigitalExcellence/dex-backend/compare/bugfix/352-dataofficer-institution-update?expand=1)
+- Resolve update institution id for data officer bug - [#352](https://github.com/DigitalExcellence/dex-backend/issues/352)
 
 ### Security
 

--- a/Postman/dex.postman_collection.json
+++ b/Postman/dex.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "1cb2e405-341a-46b7-bf51-fd09125b27c9",
+		"_postman_id": "20b49bc3-8980-4930-8148-c92b4773cfee",
 		"name": "DEV",
 		"description": "Testing Digital Excellence API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -192,7 +192,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n\t\"identityId\": \"{{dataOfficerUserIdentityId}}\",\r\n    \"name\": \"Data Officer Postman User\",\r\n    \"email\": \"dataOfficerUser@postman.com\"\r\n}",
+											"raw": "{\r\n\t\"identityId\": \"{{dataOfficerUserIdentityId}}\",\r\n    \"name\": \"Data Officer Postman User\",\r\n    \"email\": \"dataOfficerUser@postman.com\",\r\n    \"institutionId\": 1\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12314,7 +12314,7 @@
 									"response": []
 								},
 								{
-									"name": "User-UpdateUser-Self-DataOfficer",
+									"name": "User-UpdateUser-SelfWithSameInstitution-DataOfficer",
 									"event": [
 										{
 											"listen": "test",
@@ -12338,6 +12338,10 @@
 													"",
 													"pm.test(\"Check if email update matches: \" + updatedAliceEmail, function () {",
 													"    pm.expect(jsonData.email).to.eql(updatedAliceEmail);",
+													"});",
+													"",
+													"pm.test(\"Check if institution id is 1\", function () {",
+													"    pm.expect(jsonData.institution.id).to.equal(1);",
 													"});"
 												],
 												"type": "text/javascript"
@@ -12377,7 +12381,7 @@
 									"response": []
 								},
 								{
-									"name": "User-GetUser-Other-DifferentInstitution-DataOfficer",
+									"name": "User-UpdateUser-SelfWithWrongInstitution-DataOfficer",
 									"event": [
 										{
 											"listen": "test",
@@ -12387,14 +12391,18 @@
 													"",
 													"eval(pm.environment.get(\"commonTests\"))();",
 													"",
-													"pm.test(\"Status code is 403\", function () {",
-													"    pm.response.to.have.status(403);",
+													"pm.test(\"Status code is 401\", function () {",
+													"    pm.response.to.have.status(401);",
 													"});",
 													"",
 													"pm.test(\"Response must be valid and have a json body\", function () {",
-													"     pm.response.to.be.forbidden;",
+													"     pm.response.to.be.unauthorized;",
 													"     pm.response.to.be.withBody;",
 													"     pm.response.to.be.json;",
+													"});",
+													"",
+													"pm.test(\"Instance guid should be: DD72C521-1D06-4E11-A0E0-AAE515E7F900\", function () {",
+													"    pm.expect(jsonData.instance).to.equal(\"DD72C521-1D06-4E11-A0E0-AAE515E7F900\");",
 													"});",
 													""
 												],
@@ -12403,7 +12411,7 @@
 										}
 									],
 									"request": {
-										"method": "GET",
+										"method": "PUT",
 										"header": [
 											{
 												"key": "IdentityId",
@@ -12411,15 +12419,86 @@
 												"value": "{{dataOfficerUserIdentityId}}"
 											}
 										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"name\": \"postman_DataOfficer-alicez\",\r\n  \"email\": \"{{updatedAliceEmail}}\",\r\n  \"identityId\": \"{{dataOfficerUserIdentityId}}\",\r\n  \"institutionId\": {{createdInstitutionId}}\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
 										"url": {
-											"raw": "{{apiUrl}}/api/User/{{createdUserId}}",
+											"raw": "{{apiUrl}}/api/User/{{dataOfficerUserId}}",
 											"host": [
 												"{{apiUrl}}"
 											],
 											"path": [
 												"api",
 												"User",
-												"{{createdUserId}}"
+												"{{dataOfficerUserId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "User-UpdateUser-OtherWithSameInstitution-SameInstitutionId-DataOfficer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"var jsonData = pm.response.json();",
+													"var institutionId = pm.environment.get(\"institutionIdFromUser\");",
+													"",
+													"eval(pm.environment.get(\"commonTests\"))();",
+													"",
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must be valid and have a json body\", function () {",
+													"     pm.response.to.be.ok;",
+													"     pm.response.to.be.withBody;",
+													"     pm.response.to.be.json;",
+													"});",
+													"",
+													"pm.test(\"Institution Id is \" + institutionId, function() {",
+													"    pm.expect(jsonData.institution.id).to.equal(parseInt(institutionId));",
+													"})"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "IdentityId",
+												"type": "text",
+												"value": "{{dataOfficerUserIdentityId}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"name\": \"bobz\",\r\n  \"email\": \"BobSmith@email.com\",\r\n  \"identityId\": {{administratorUserIdentityId}},\r\n  \"institutionId\": {{institutionIdFromUser}}\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{apiUrl}}/api/User/{{createdUserWithInstitutionId}}",
+											"host": [
+												"{{apiUrl}}"
+											],
+											"path": [
+												"api",
+												"User",
+												"{{createdUserWithInstitutionId}}"
 											]
 										}
 									},
@@ -12475,16 +12554,13 @@
 									"response": []
 								},
 								{
-									"name": "User-GetUser-Self-DataOfficer",
+									"name": "User-UpdateUser-OtherWithSameInstitution-NoInstitutionId-DataOfficer",
 									"event": [
 										{
 											"listen": "test",
 											"script": {
 												"exec": [
-													"var aliceIdentityId = parseInt(pm.environment.get(\"dataOfficerUserIdentityId\"));",
-													"",
 													"var jsonData = pm.response.json();",
-													"pm.environment.set(\"dataOfficerUserId\", jsonData.id);",
 													"",
 													"eval(pm.environment.get(\"commonTests\"))();",
 													"",
@@ -12498,8 +12574,8 @@
 													"     pm.response.to.be.json;",
 													"});",
 													"",
-													"pm.test(\"Identity ID is correct and matching: \" + aliceIdentityId, function () {",
-													"    pm.expect(parseInt(jsonData.identityId)).to.eql(aliceIdentityId);",
+													"pm.test(\"Check if institution is null\", function () {",
+													"    pm.expect(jsonData.institution).to.equal(null);",
 													"});"
 												],
 												"type": "text/javascript"
@@ -12507,7 +12583,7 @@
 										}
 									],
 									"request": {
-										"method": "GET",
+										"method": "PUT",
 										"header": [
 											{
 												"key": "IdentityId",
@@ -12515,14 +12591,24 @@
 												"value": "{{dataOfficerUserIdentityId}}"
 											}
 										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"name\": \"bobz\",\r\n  \"email\": \"BobSmith@email.com\",\r\n  \"identityId\": {{administratorUserIdentityId}}\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
 										"url": {
-											"raw": "{{apiUrl}}/api/User",
+											"raw": "{{apiUrl}}/api/User/{{createdUserWithInstitutionId}}",
 											"host": [
 												"{{apiUrl}}"
 											],
 											"path": [
 												"api",
-												"User"
+												"User",
+												"{{createdUserWithInstitutionId}}"
 											]
 										}
 									},
@@ -12572,6 +12658,55 @@
 											}
 										},
 										"url": {
+											"raw": "{{apiUrl}}/api/User/{{createdUserWithInstitutionId}}",
+											"host": [
+												"{{apiUrl}}"
+											],
+											"path": [
+												"api",
+												"User",
+												"{{createdUserWithInstitutionId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "User-GetUser-Other-DifferentInstitution-DataOfficer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"var jsonData = pm.response.json();",
+													"",
+													"eval(pm.environment.get(\"commonTests\"))();",
+													"",
+													"pm.test(\"Status code is 403\", function () {",
+													"    pm.response.to.have.status(403);",
+													"});",
+													"",
+													"pm.test(\"Response must be valid and have a json body\", function () {",
+													"     pm.response.to.be.forbidden;",
+													"     pm.response.to.be.withBody;",
+													"     pm.response.to.be.json;",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "IdentityId",
+												"type": "text",
+												"value": "{{dataOfficerUserIdentityId}}"
+											}
+										],
+										"url": {
 											"raw": "{{apiUrl}}/api/User/{{createdUserId}}",
 											"host": [
 												"{{apiUrl}}"
@@ -12580,6 +12715,60 @@
 												"api",
 												"User",
 												"{{createdUserId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "User-GetUser-Self-DataOfficer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"var aliceIdentityId = parseInt(pm.environment.get(\"dataOfficerUserIdentityId\"));",
+													"",
+													"var jsonData = pm.response.json();",
+													"pm.environment.set(\"dataOfficerUserId\", jsonData.id);",
+													"",
+													"eval(pm.environment.get(\"commonTests\"))();",
+													"",
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must be valid and have a json body\", function () {",
+													"     pm.response.to.be.ok;",
+													"     pm.response.to.be.withBody;",
+													"     pm.response.to.be.json;",
+													"});",
+													"",
+													"pm.test(\"Identity ID is correct and matching: \" + aliceIdentityId, function () {",
+													"    pm.expect(parseInt(jsonData.identityId)).to.eql(aliceIdentityId);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "IdentityId",
+												"type": "text",
+												"value": "{{dataOfficerUserIdentityId}}"
+											}
+										],
+										"url": {
+											"raw": "{{apiUrl}}/api/User",
+											"host": [
+												"{{apiUrl}}"
+											],
+											"path": [
+												"api",
+												"User"
 											]
 										}
 									},
@@ -15018,6 +15207,73 @@
 						{
 							"name": "Cleanup Data Officer",
 							"item": [
+								{
+									"name": "User-UpdateUser-SelfWithNoInstitution-DataOfficer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"var updatedAliceEmail = pm.environment.get(\"updatedAliceEmail\");",
+													"",
+													"var jsonData = pm.response.json();",
+													"",
+													"eval(pm.environment.get(\"commonTests\"))();",
+													"",
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must be valid and have a json body\", function () {",
+													"     pm.response.to.be.ok;",
+													"     pm.response.to.be.withBody;",
+													"     pm.response.to.be.json;",
+													"});",
+													"",
+													"pm.test(\"Check if email update matches: \" + updatedAliceEmail, function () {",
+													"    pm.expect(jsonData.email).to.eql(updatedAliceEmail);",
+													"});",
+													"",
+													"pm.test(\"Check if institution is null\", function () {",
+													"    pm.expect(jsonData.institution).to.equal(null);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "IdentityId",
+												"type": "text",
+												"value": "{{dataOfficerUserIdentityId}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"name\": \"postman_DataOfficer-alicez\",\r\n  \"email\": \"{{updatedAliceEmail}}\",\r\n  \"identityId\": \"{{dataOfficerUserIdentityId}}\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{apiUrl}}/api/User/{{dataOfficerUserId}}",
+											"host": [
+												"{{apiUrl}}"
+											],
+											"path": [
+												"api",
+												"User",
+												"{{dataOfficerUserId}}"
+											]
+										}
+									},
+									"response": []
+								},
 								{
 									"name": "Project-DeleteProject-Self-DataOfficer",
 									"event": [

--- a/Postman/dex.postman_collection.json
+++ b/Postman/dex.postman_collection.json
@@ -12483,7 +12483,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n  \"name\": \"bobz\",\r\n  \"email\": \"BobSmith@email.com\",\r\n  \"identityId\": {{administratorUserIdentityId}},\r\n  \"institutionId\": {{institutionIdFromUser}}\r\n}",
+											"raw": "{\r\n  \"name\": \"bobz\",\r\n  \"email\": \"BobSmith@email.com\",\r\n  \"institutionId\": {{institutionIdFromUser}},\r\n  \"identityId\": \"9996\"\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12593,7 +12593,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n  \"name\": \"bobz\",\r\n  \"email\": \"BobSmith@email.com\",\r\n  \"identityId\": {{administratorUserIdentityId}}\r\n}",
+											"raw": "{\r\n  \"name\": \"bobz\",\r\n  \"email\": \"BobSmith@email.com\",\r\n  \"identityId\": \"9996\"\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12650,7 +12650,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n  \"name\": \"bobz\",\r\n  \"email\": \"BobSmith@email.com\",\r\n  \"identityId\": {{administratorUserIdentityId}}\r\n}",
+											"raw": "{\r\n  \"name\": \"bobz\",\r\n  \"email\": \"BobSmith@email.com\",\r\n  \"identityId\": \"9996\"\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -15208,73 +15208,6 @@
 							"name": "Cleanup Data Officer",
 							"item": [
 								{
-									"name": "User-UpdateUser-SelfWithNoInstitution-DataOfficer",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"exec": [
-													"var updatedAliceEmail = pm.environment.get(\"updatedAliceEmail\");",
-													"",
-													"var jsonData = pm.response.json();",
-													"",
-													"eval(pm.environment.get(\"commonTests\"))();",
-													"",
-													"pm.test(\"Status code is 200\", function () {",
-													"    pm.response.to.have.status(200);",
-													"});",
-													"",
-													"pm.test(\"Response must be valid and have a json body\", function () {",
-													"     pm.response.to.be.ok;",
-													"     pm.response.to.be.withBody;",
-													"     pm.response.to.be.json;",
-													"});",
-													"",
-													"pm.test(\"Check if email update matches: \" + updatedAliceEmail, function () {",
-													"    pm.expect(jsonData.email).to.eql(updatedAliceEmail);",
-													"});",
-													"",
-													"pm.test(\"Check if institution is null\", function () {",
-													"    pm.expect(jsonData.institution).to.equal(null);",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "PUT",
-										"header": [
-											{
-												"key": "IdentityId",
-												"type": "text",
-												"value": "{{dataOfficerUserIdentityId}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\r\n  \"name\": \"postman_DataOfficer-alicez\",\r\n  \"email\": \"{{updatedAliceEmail}}\",\r\n  \"identityId\": \"{{dataOfficerUserIdentityId}}\"\r\n}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{apiUrl}}/api/User/{{dataOfficerUserId}}",
-											"host": [
-												"{{apiUrl}}"
-											],
-											"path": [
-												"api",
-												"User",
-												"{{dataOfficerUserId}}"
-											]
-										}
-									},
-									"response": []
-								},
-								{
 									"name": "Project-DeleteProject-Self-DataOfficer",
 									"event": [
 										{
@@ -15353,7 +15286,7 @@
 											{
 												"key": "IdentityId",
 												"type": "text",
-												"value": "{{administratorUserIdentityId}}"
+												"value": "{{dataOfficerUserIdentityId}}"
 											}
 										],
 										"url": {
@@ -15365,6 +15298,73 @@
 												"api",
 												"Project",
 												"{{projectIdWithInstitution}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "User-UpdateUser-SelfWithNoInstitution-DataOfficer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"var updatedAliceEmail = pm.environment.get(\"updatedAliceEmail\");",
+													"",
+													"var jsonData = pm.response.json();",
+													"",
+													"eval(pm.environment.get(\"commonTests\"))();",
+													"",
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must be valid and have a json body\", function () {",
+													"     pm.response.to.be.ok;",
+													"     pm.response.to.be.withBody;",
+													"     pm.response.to.be.json;",
+													"});",
+													"",
+													"pm.test(\"Check if email update matches: \" + updatedAliceEmail, function () {",
+													"    pm.expect(jsonData.email).to.eql(updatedAliceEmail);",
+													"});",
+													"",
+													"pm.test(\"Check if institution is null\", function () {",
+													"    pm.expect(jsonData.institution).to.equal(null);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "IdentityId",
+												"type": "text",
+												"value": "{{dataOfficerUserIdentityId}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"name\": \"postman_DataOfficer-alicez\",\r\n  \"email\": \"{{updatedAliceEmail}}\",\r\n  \"identityId\": \"{{dataOfficerUserIdentityId}}\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{apiUrl}}/api/User/{{dataOfficerUserId}}",
+											"host": [
+												"{{apiUrl}}"
+											],
+											"path": [
+												"api",
+												"User",
+												"{{dataOfficerUserId}}"
 											]
 										}
 									},


### PR DESCRIPTION
## Description

People can't add themselves to an institution. This was possible and data officers were able to switch institutions and retrieve access to institutions they should not have access to.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I did not update API Controllers, if I did, I added/changed Postman tests
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

1. Validate you can update your own account, except updating your institution id.
2. Validate a data officer can update the data from users from their institution, except updating the institution id. They should be able to delete users from their institution. 

## Link to issue

Closes: #352 
