### PR TITLE
Bugfix/436 dont get description for getall projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed the get all projects query - [#436](https://github.com/DigitalExcellence/dex-backend/issues/436)
+- Removed getting the description for the projects get all query - [#436](https://github.com/DigitalExcellence/dex-backend/issues/436)
 ### Security
 
 

--- a/Repositories/ProjectRepository.cs
+++ b/Repositories/ProjectRepository.cs
@@ -203,12 +203,33 @@ namespace Repositories
                 .Include(p => p.Likes)
                 .Include(p => p.LinkedInstitutions)
                 .Include(p => p.Categories)
-                    .ThenInclude(c => c.Category);
+                    .ThenInclude(c => c.Category)
+                  //Don't get the description for performance reasons.
+                  .Select(p => new Project
+                  {
+                      UserId = p.UserId,
+                      User = p.User,
+                      Id = p.Id,
+                      ProjectIconId = p.ProjectIconId,
+                      ProjectIcon = p.ProjectIcon,
+                      CallToAction = p.CallToAction,
+                      Collaborators = p.Collaborators,
+                      Likes = p.Likes,
+                      LinkedInstitutions = p.LinkedInstitutions,
+                      Categories = p.Categories,
+                      Created = p.Created,
+                      InstitutePrivate = p.InstitutePrivate,
+                      Name = p.Name,
+                      ShortDescription = p.ShortDescription,
+                      Updated = p.Updated,
+                      Uri = p.Uri
+                  });
 
             queryableProjects = ApplyFilters(queryableProjects, skip, take, orderBy, orderByAsc, highlighted);
 
             //Execute the IQueryable to get a collection of results
-            List<Project> projectResults = await queryableProjects.ToListAsync();
+            List<Project> projectResults = await queryableProjects
+                .ToListAsync();
 
             //Redact the user after fetching the collection from the project (no separate query needs to be executed)
             projectResults.ForEach(project => project.User = RedactUser(project.User));


### PR DESCRIPTION
## Description

Dotnet awesome on the staging and production env. Makes getting the projects very slow for some reason. We think it is because we get the description from the database even when we don't need them. This change makes it so we don't get the description anymore when doing the getall query to the database

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I did not update API Controllers, if I did, I added/changed Postman tests
-   [X] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [X] I updated the changelog with an end-user readable description
-   [X] I assigned this pull request to the correct project board to update the sprint board

## Link to issue

Closes: #436
