### PR TITLE
Swagger authorization fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Performance testing using K6 - [#379](https://github.com/DigitalExcellence/dex-backend/issues/379)
 
 ### Changed
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Able to remove images from project - [#454](https://github.com/DigitalExcellence/dex-backend/issues/454)
+- Fixed an issue where Swagger could not authorize with IdentityServer - [#429](https://github.com/DigitalExcellence/dex-backend/issues/429)
 
 ### Security
 

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -104,8 +104,8 @@ services:
       - App__Frontend__PostLogoutUriFrontend=https://dex.software/
       - App__Frontend__ClientId=${FRONTEND_CLIENT_ID}
       - App__Frontend__ClientSecret=${FRONTEND_CLIENT_SECRET}
-      - App__swagger__RedirectUrisSwagger=https://dex.software/oauth2-redirect.html
-      - App__swagger__PostLogoutUrisSwagger=https://dex.software
+      - App__swagger__RedirectUrisSwagger=https://api.dex.software/oauth2-redirect.html
+      - App__swagger__PostLogoutUrisSwagger=https://api.dex.software
       - App__FfhictOIDC__ClientId=${FFHICTOIDC_CLIENT_ID}
       - App__FfhictOIDC__ClientSecret=${FFHICTOIDC_CLIENT_SECRET}
       - App__FfhictOIDC__RedirectUri=https://identity.dex.software/external/callback/fhict

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -111,8 +111,8 @@ services:
       - App__Frontend__PostLogoutUriFrontend=https://staging.dex.software/
       - App__Frontend__ClientId=${FRONTEND_CLIENT_ID}
       - App__Frontend__ClientSecret=${FRONTEND_CLIENT_SECRET}
-      - App__swagger__RedirectUrisSwagger=https://staging.dex.software/oauth2-redirect.html
-      - App__swagger__PostLogoutUrisSwagger=https://staging.dex.software
+      - App__swagger__RedirectUrisSwagger=https://api.staging.dex.software/oauth2-redirect.html
+      - App__swagger__PostLogoutUrisSwagger=https://api.staging.dex.software
       - App__FfhictOIDC__ClientId=${FFHICTOIDC_CLIENT_ID}
       - App__FfhictOIDC__ClientSecret=${FFHICTOIDC_CLIENT_SECRET}
       - App__FfhictOIDC__RedirectUri=https://identity.staging.dex.software/external/callback/fhict


### PR DESCRIPTION
## Description

Swagger got an "unauthorized_client" error on https://api.staging.dex.software/ and https://api.dex.software/
I already changed the docker-compose files on both servers.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I did not update API Controllers, if I did, I added/changed Postman tests
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

I already changed the docker-compose files on both servers for testing purposes.
Swagger now works again. Test it at: https://api.staging.dex.software/

## Link to issue

Closes: #429 
