### PR TITLE
Lowercase file extensions

### DIFF
--- a/API/ControllerAttributes/AllowedFileExtensionsAttribute.cs
+++ b/API/ControllerAttributes/AllowedFileExtensionsAttribute.cs
@@ -61,7 +61,7 @@ namespace API.ControllerAttributes
             {
                 string fileExtension = Path.GetExtension(file.FileName);
                 // Check if file extension is allowed
-                if(!allowedExtensions.Contains(fileExtension))
+                if(!allowedExtensions.Contains(fileExtension.ToLower()))
                 {
                     fileExtensionsAreValid = false;
                     ProblemDetails problem = new ProblemDetails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Performance testing using K6 - [#379](https://github.com/DigitalExcellence/dex-backend/issues/379)
 
 ### Changed
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Able to remove images from project - [#454](https://github.com/DigitalExcellence/dex-backend/issues/454)
+- Lowercase file extensions on upload - [#472](https://github.com/DigitalExcellence/dex-backend/issues/472)
 
 ### Security
 


### PR DESCRIPTION
## Description

File extensions are now always lowercased. This makes it possible to also upload .PNG, .JPEG, .JPG and .GIF (in caps) files.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I did not update API Controllers, if I did, I added/changed Postman tests
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Upload file with extension in caps. You can use snipping tool in Windows to create a .PNG file.

## Link to issue

Closes: #472 
