### PR TITLE
added delete cascade for ProjectTransferRequest

### DIFF
--- a/Data/Migrations/20211203095510_addedCascadeForTransferRequest.Designer.cs
+++ b/Data/Migrations/20211203095510_addedCascadeForTransferRequest.Designer.cs
@@ -4,14 +4,16 @@ using Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace _4_Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211203095510_addedCascadeForTransferRequest")]
+    partial class addedCascadeForTransferRequest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20211203095510_addedCascadeForTransferRequest.cs
+++ b/Data/Migrations/20211203095510_addedCascadeForTransferRequest.cs
@@ -1,0 +1,91 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace _4_Data.Migrations
+{
+    public partial class addedCascadeForTransferRequest : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProjectTransferRequest_User_PotentialNewOwnerId",
+                table: "ProjectTransferRequest");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProjectTransferRequest_Project_ProjectId",
+                table: "ProjectTransferRequest");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ProjectId",
+                table: "ProjectTransferRequest",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "PotentialNewOwnerId",
+                table: "ProjectTransferRequest",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProjectTransferRequest_User_PotentialNewOwnerId",
+                table: "ProjectTransferRequest",
+                column: "PotentialNewOwnerId",
+                principalTable: "User",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProjectTransferRequest_Project_ProjectId",
+                table: "ProjectTransferRequest",
+                column: "ProjectId",
+                principalTable: "Project",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProjectTransferRequest_User_PotentialNewOwnerId",
+                table: "ProjectTransferRequest");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProjectTransferRequest_Project_ProjectId",
+                table: "ProjectTransferRequest");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ProjectId",
+                table: "ProjectTransferRequest",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int));
+
+            migrationBuilder.AlterColumn<int>(
+                name: "PotentialNewOwnerId",
+                table: "ProjectTransferRequest",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int));
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProjectTransferRequest_User_PotentialNewOwnerId",
+                table: "ProjectTransferRequest",
+                column: "PotentialNewOwnerId",
+                principalTable: "User",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProjectTransferRequest_Project_ProjectId",
+                table: "ProjectTransferRequest",
+                column: "ProjectId",
+                principalTable: "Project",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/Models/ProjectTransferRequest.cs
+++ b/Models/ProjectTransferRequest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 
 namespace Models
@@ -19,7 +20,10 @@ namespace Models
         }
 
         public int Id { get; set; }
+
+        [Required]
         public Project Project { get; set; }
+        [Required]
         public User PotentialNewOwner { get; set; }
 
         public bool CurrentOwnerAcceptedRequest { get; set; }


### PR DESCRIPTION
## Description

This small PR adds a cascade delete to the ProjectTransferRequest table. At this moment when a project has an entry in the project transfer request table the project can not be deleted. The reason is that it violates the foreign key constraint.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I did not update API Controllers, if I did, I added/changed Postman or XUnit integration tests
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] I updated the changelog with an end-user readable description
-   [ ] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Create a project and initialize a transfer to another user(just use the email from a seeded user in DB).
The transfer only needs to be initialized and does not need to be finished. After initializing the transfer try deleting your project. This should work and the transfer request should also be deleted in the transfer request table.

1. Create project
2. Init transfer
3. Succesfully delete your project

## Link to issue

Closes: #541 
