### PR TITLE
Feature/search for multiple projects by id

### DIFF
--- a/API.Tests/Controllers/ProjectControllerTests.cs
+++ b/API.Tests/Controllers/ProjectControllerTests.cs
@@ -147,5 +147,54 @@ namespace API.Tests.Controllers
             // Assert
             response.StatusCode.Should().Be(expectedResult);
         }
+
+
+        [Theory]
+        [InlineData(UserRole.Alumni, HttpStatusCode.OK)]
+        [InlineData(UserRole.Admin, HttpStatusCode.OK)]
+        [InlineData(UserRole.DataOfficer, HttpStatusCode.OK)]
+        [InlineData(UserRole.PrUser, HttpStatusCode.OK)]
+        [InlineData(UserRole.RegisteredUser, HttpStatusCode.OK)]
+        public async Task GetProjects_By_Multiple_Ids_Returns_OK_Result_For_All_Roles(UserRole role, HttpStatusCode expectedResult)
+        {
+            // Arrange
+            await AuthenticateAs(role);
+
+            int[] existingProjectIds = new int[] { 1,2,3,10,15,20,30 };
+
+            // Act
+            HttpResponseMessage response = await TestClient.PostAsJsonAsync("project/multiple", existingProjectIds);
+
+            // Assert
+            response.StatusCode.Should().Be(expectedResult);
+        }
+
+
+        [Theory]
+        [InlineData(UserRole.Alumni, 7)]
+        [InlineData(UserRole.Admin, 7)]
+        [InlineData(UserRole.DataOfficer, 7)]
+        [InlineData(UserRole.PrUser, 7)]
+        [InlineData(UserRole.RegisteredUser, 7)]
+        public async Task GetProjects_By_Multiple_Ids_Returns_Correct_Count_Result_For_All_Roles(UserRole role, int expectedCount)
+        {
+            // Arrange
+            await AuthenticateAs(role);
+
+            int[] existingProjectIds = new int[] { 1, 2, 3, 10, 15, 20, 30 };
+
+            // Act
+            HttpResponseMessage response = await TestClient.PostAsJsonAsync("Project/multiple", existingProjectIds);
+            string result = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            if(response.IsSuccessStatusCode)
+            {
+                List<ProjectOutput> projectOutputs = JsonConvert.DeserializeObject<List<ProjectOutput>>(result);
+                Assert.Equal(expectedCount, projectOutputs.Count);
+            }
+
+            Assert.True(false);
+        }
     }
 }

--- a/API.Tests/Controllers/ProjectControllerTests.cs
+++ b/API.Tests/Controllers/ProjectControllerTests.cs
@@ -163,7 +163,7 @@ namespace API.Tests.Controllers
             int[] existingProjectIds = new int[] { 1,2,3,10,15,20,30 };
 
             // Act
-            HttpResponseMessage response = await TestClient.PostAsJsonAsync("project/multiple", existingProjectIds);
+            HttpResponseMessage response = await TestClient.PostAsJsonAsync("Project/multiple", existingProjectIds);
 
             // Assert
             response.StatusCode.Should().Be(expectedResult);
@@ -192,9 +192,10 @@ namespace API.Tests.Controllers
             {
                 List<ProjectOutput> projectOutputs = JsonConvert.DeserializeObject<List<ProjectOutput>>(result);
                 Assert.Equal(expectedCount, projectOutputs.Count);
+            } else
+            {
+                Assert.True(false);
             }
-
-            Assert.True(false);
         }
     }
 }

--- a/API/Controllers/ProjectController.cs
+++ b/API/Controllers/ProjectController.cs
@@ -285,6 +285,30 @@ namespace API.Controllers
 
 
         /// <summary>
+        /// Find multiple projects by their ids.
+        /// </summary>
+        /// <param name="ids"></param>
+        /// <returns></returns>
+        [HttpPost("multiple")]
+        [ProducesResponseType(typeof(List<ProjectOutput>), (int) HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ProblemDetails), 503)]
+        public async Task<IActionResult> FindByMultipleIds(int [] ids)
+        {
+            try
+            {
+                List<ProjectOutput> projectOutputs = mapper.Map<List<Project>, List<ProjectOutput>>(await projectService.FindAsyncByMultipleIds(ids));
+
+                if(projectOutputs != null && projectOutputs.Any()) return Ok(projectOutputs);
+
+                return NotFound("Could not find any projects matching the ids");
+                   
+            } catch(Exception)
+            {
+                return BadRequest();
+            }
+        }
+
+        /// <summary>
         ///     This method is responsible for retrieving a single project.
         /// </summary>
         /// <returns>This method returns the project resource result.</returns>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Release v.2.1.0-beta - DATE HERE
+### Added
+- Added endpoint to search for projects by multiple ids - [#547](https://github.com/DigitalExcellence/dex-backend/pull/553)
+
+
+
+
 ## Release v.2.0.0-beta - DATE HERE
 ### Added
 - Added JobScheduler unit tests - [#381](https://github.com/DigitalExcellence/dex-backend/pull/539)

--- a/Repositories/ProjectRepository.cs
+++ b/Repositories/ProjectRepository.cs
@@ -73,6 +73,15 @@ namespace Repositories
         /// <returns></returns>
         Task<Project> FindAsyncNotRedacted(int id);
 
+
+
+        /// <summary>
+        /// Find multiple projects by their id
+        /// </summary>
+        /// <param name="ids"></param>
+        /// <returns></returns>
+        Task<List<Project>> FindAsyncByMultipleIds(int [] ids);
+
         /// <summary>
         ///     This interface method counts the amount of projects matching the filters.
         /// </summary>
@@ -874,6 +883,18 @@ namespace Repositories
         public Task<Project> FindAsyncNotRedacted(int id)
         {
             return GetDbSet<Project>().Where(p => p.Id == id).Include(u => u.User).FirstOrDefaultAsync();
+        }
+
+        Task<List<Project>> IProjectRepository.FindAsyncByMultipleIds(int[] ids)
+        {
+            return GetDbSet<Project>().Where(p => ids.Contains(p.Id))
+                .Include(p => p.User)
+                .Include(p => p.Tags)
+                .Include(p => p.Categories)
+                .Include(p => p.Likes)
+                .Include(p => p.CallToActions)
+                .Include(p => p.ProjectIcon)
+                .ToListAsync();
         }
     }
 }

--- a/Services/Services/ProjectService.cs
+++ b/Services/Services/ProjectService.cs
@@ -56,6 +56,14 @@ namespace Services.Services
         /// <returns></returns>
         Task<Project> FindAsyncNotRedacted(int id);
 
+
+        /// <summary>
+        /// Find multiple projects by their ids
+        /// </summary>
+        /// <param name="ids"></param>
+        /// <returns></returns>
+        Task<List<Project>> FindAsyncByMultipleIds(int[] ids);
+
         /// <summary>
         ///     Get the number of projects
         /// </summary>
@@ -311,6 +319,11 @@ namespace Services.Services
         public async Task<Project> FindAsyncNotRedacted(int id)
         {
             return await Repository.FindAsyncNotRedacted(id);
+        }
+
+        async Task<List<Project>> IProjectService.FindAsyncByMultipleIds(int[] ids)
+        {
+            return await Repository.FindAsyncByMultipleIds(ids);
         }
     }
 


### PR DESCRIPTION
## Description

This PR adds the possibility to search for projects by multiple ids.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I did not update API Controllers, if I did, I added/changed Postman or XUnit integration tests
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] I updated the changelog with an end-user readable description
-   [ ] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Go to the project/multiple endpoint and do a POST request with an array of project id's in the body.
The endpoint should return all projects according to the array of ids.


1. Make sure the project id's exist
2. go to project/multiple and make a POST call with an int[] array of project ids.
3. The projects matching the id's are returned.
4. If no projects are found 404 should be returned.

## #547 

Closes: #547 
